### PR TITLE
Add default Accept/charset headers to Jaggaer web client

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerOAuth2Config.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerOAuth2Config.java
@@ -1,5 +1,9 @@
 package uk.gov.crowncommercial.dts.scale.cat.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.ACCEPT_CHARSET;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.util.Arrays;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -81,7 +85,9 @@ public class JaggaerOAuth2Config {
     ClientHttpConnector jettyHttpClientConnector = new JettyClientHttpConnector(client);
 
     return WebClient.builder().clientConnector(jettyHttpClientConnector)
-        .baseUrl(jaggaerAPIConfig.getBaseUrl()).apply(oauth2Client.oauth2Configuration()).build();
+        .baseUrl(jaggaerAPIConfig.getBaseUrl()).defaultHeader(ACCEPT, APPLICATION_JSON_VALUE)
+        .defaultHeader(ACCEPT_CHARSET, UTF_8.name()).apply(oauth2Client.oauth2Configuration())
+        .build();
   }
 
 }


### PR DESCRIPTION
Not 100% convinced this is going to solve the issue Sabarish is having (again, this afternoon) - but it might, based on the errors I've seen and reading around it (the logs show a mime-type error from the web client when processing the response from Jaggaer in the `UserProfileService` class, which seems to relate to the handling of the `application/json; charset=UTF-8` Content-type).