### PR TITLE
Create project with "DIVISION" project team

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
@@ -15,6 +15,7 @@ public class JaggaerAPIConfig {
 
   private String baseUrl;
   private Integer timeoutDuration;
+  private Boolean addDivisionToProjectTeam;
   private Map<String, String> createProject;
   private Map<String, String> createEvent;
   private Map<String, String> getBuyerCompanyProfile;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ProjectTeam.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ProjectTeam.java
@@ -4,12 +4,14 @@ import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+/**
+ *
+ */
 @Value
 @Builder
 @Jacksonized
-public class Project {
+public class ProjectTeam {
 
-  Tender tender;
-  ProjectTeam projectTeam;
+  String code;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/User.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/User.java
@@ -1,6 +1,5 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.jaggaer;
 
-import java.util.Set;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
@@ -11,8 +10,10 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Builder
 @Jacksonized
-public class ProjectTeam {
+public class User {
 
-  Set<User> user;
+  String code;
+  String id;
+  String login;
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,8 @@ config:
   external:
     jaggaer:
       baseUrl: https://crowncommercialservice-ws02-prep.bravosolution.co.uk
-      timeoutDuration: 5 
+      timeoutDuration: 5
+      addDivisionToProjectTeam: false
       createProject:
         # CA-Lot-BuyerOrg e.g. RM1234-Lot1a-CCS
         defaultTitleFormat: "%s-%s-%s"

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
@@ -164,7 +164,8 @@ class ProcurementProjectServiceTest {
     createUpdateProjectResponse.setReturnMessage("OK");
 
     var tender = Tender.builder().title(UPDATED_PROJECT_NAME).build();
-    var createUpdateProject = new CreateUpdateProject(OperationCode.UPDATE, new Project(tender));
+    var createUpdateProject =
+        new CreateUpdateProject(OperationCode.UPDATE, Project.builder().tender(tender).build());
 
     // Mock behaviours
     when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
@@ -224,7 +225,7 @@ class ProcurementProjectServiceTest {
    */
   private class UpdateProjectMatcher implements ArgumentMatcher<CreateUpdateProject> {
 
-    private CreateUpdateProject left;
+    private final CreateUpdateProject left;
 
     UpdateProjectMatcher(CreateUpdateProject left) {
       this.left = left;


### PR DESCRIPTION
Default behaviour is to not add this, at least for now (driven by `config.external.jaggaer.addDivisionToProjectTeam` env var) as everyone in CCS with an account on the sales platform is in the same division.  Ideally we need to ask for a new division with just us in it for testing purposes I guess 🤔 