### PR TITLE
Filter function to normalise Jaggaer API 401 response

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
@@ -14,6 +14,8 @@ import lombok.Data;
 public class JaggaerAPIConfig {
 
   private String baseUrl;
+  private String headerValueWWWAuthenticate;
+  private String headerValueInvalidContentType;
   private Integer timeoutDuration;
   private Boolean addDivisionToProjectTeam;
   private Map<String, String> createProject;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerOAuth2Config.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerOAuth2Config.java
@@ -115,7 +115,7 @@ public class JaggaerOAuth2Config {
    * Fixes Jaggaer REST API response for 401 Unauthorized (issues are invalid content-type and
    * missing WWW-Authenticate header)
    *
-   * @return
+   * @return the configured filter function to mutate the response
    */
   private ExchangeFilterFunction buildResponseHeaderFilterFunction() {
     return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,8 @@ config:
       baseUrl: https://crowncommercialservice-ws02-prep.bravosolution.co.uk
       timeoutDuration: 5
       addDivisionToProjectTeam: false
+      headerValueInvalidContentType: "; charset=UTF-8"
+      headerValueWWWAuthenticate: 'Bearer error="invalid_or_missing_token"'
       createProject:
         # CA-Lot-BuyerOrg e.g. RM1234-Lot1a-CCS
         defaultTitleFormat: "%s-%s-%s"


### PR DESCRIPTION
Hoping this will suffice as a workaround to the issues with Jaggaer's 401 response - but need to find a better way of testing its effectiveness than waiting 24hrs for the token to expire in my local service instance!