### PR TITLE
Remove invalid Content-Type header and values

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerOAuth2Config.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerOAuth2Config.java
@@ -134,7 +134,10 @@ public class JaggaerOAuth2Config {
         if (clientResponse.headers().header(CONTENT_TYPE)
             .contains(jaggaerAPIConfig.getHeaderValueInvalidContentType())) {
           log.debug("Jaggaer 401 - correcting Content-Type header");
-          clientResponseMutator.header(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+          clientResponseMutator.headers(httpHeaders -> {
+            httpHeaders.remove(CONTENT_TYPE);
+            httpHeaders.add(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+          });
         }
       }
 


### PR DESCRIPTION
Small update - error on INT was back to the original problem, and I think it's because I hadn't removed the existing malformed content-type header and value.  Delving into the code, the `HttpHeaders.add` method just appends an additional value to an existing header if it exists - so in this case we need to remove it completely first 👍 