### PR TITLE
Bugfix/scc 517 jaggaer token expiry

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
@@ -18,6 +18,7 @@ public class JaggaerAPIConfig {
   private String headerValueInvalidContentType;
   private Integer timeoutDuration;
   private Boolean addDivisionToProjectTeam;
+  private Long tokenExpirySeconds;
   private Map<String, String> createProject;
   private Map<String, String> createEvent;
   private Map<String, String> getBuyerCompanyProfile;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerTokenResponseConverter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerTokenResponseConverter.java
@@ -1,27 +1,37 @@
 package uk.gov.crowncommercial.dts.scale.cat.config;
 
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Converts from Jaggaer's non-standard token response to {@link OAuth2AccessTokenResponse}
  */
 @Component
+@RequiredArgsConstructor
+@Slf4j
 public class JaggaerTokenResponseConverter
     implements Converter<Map<String, String>, OAuth2AccessTokenResponse> {
 
   static final String JAGGAER_TOKEN_PROPERTY = "token";
-  static final String JAGGAER_EXPIRE_IN_PROPERTY = "expire_in";
+  static final String JAGGAER_EXPIRE_IN_MILLIS_PROPERTY = "expire_in";
+
+  private final JaggaerAPIConfig jaggaerAPIConfig;
 
   @Override
   public OAuth2AccessTokenResponse convert(Map<String, String> tokenResponse) {
 
+    var tokenExpirySeconds = Optional.ofNullable(jaggaerAPIConfig.getTokenExpirySeconds())
+        .orElse(Long.parseLong(tokenResponse.get(JAGGAER_EXPIRE_IN_MILLIS_PROPERTY)) / 1000);
+    log.debug("Jaggaer token expiry set to [{}] seconds", tokenExpirySeconds);
+
     return OAuth2AccessTokenResponse.withToken(tokenResponse.get(JAGGAER_TOKEN_PROPERTY))
-        .tokenType(OAuth2AccessToken.TokenType.BEARER)
-        .expiresIn(Long.parseLong(tokenResponse.get(JAGGAER_EXPIRE_IN_PROPERTY))).build();
+        .tokenType(OAuth2AccessToken.TokenType.BEARER).expiresIn(tokenExpirySeconds).build();
   }
 
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
@@ -32,6 +32,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.service.ProcurementEventService;
@@ -41,7 +42,7 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
  * Controller tests
  */
 @WebMvcTest(EventsController.class)
-@Import({TendersAPIModelUtils.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class})
 @ActiveProfiles("test")
 class EventsControllerTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.ProcurementProjectName;
@@ -41,7 +42,7 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
  * Web (mock MVC) Project controller tests. Security aware.
  */
 @WebMvcTest(ProjectsController.class)
-@Import({TendersAPIModelUtils.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class})
 @ActiveProfiles("test")
 class ProjectsControllerTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.service.ProcurementProjectService;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 
@@ -30,7 +31,7 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
  * Web (mock MVC) Tenders controller tests. Security aware.
  */
 @WebMvcTest(TendersController.class)
-@Import({TendersAPIModelUtils.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class})
 @ActiveProfiles("test")
 class TendersControllerTest {
 


### PR DESCRIPTION
Ok - mystery solved as to why the stored token was never expiring (it comes back in millis and wasn't being converted to seconds - now it is) - hopefully this will fix it, and if the issue persists then we can hardcode a lower expiry in seconds via env var `config.external.jaggaer.tokenExpirySeconds` 🤦‍♂️ 