### PR TITLE
Supplier mappings from AS and buyer org

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/AgreementsServiceAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/AgreementsServiceAPIConfig.java
@@ -21,6 +21,7 @@ public class AgreementsServiceAPIConfig {
   private Map<String, String> getAgreementDetail;
   private Map<String, String> getLotDetailsForAgreement;
   private Map<String, String> getLotEventTypeDataTemplates;
+  private Map<String, String> getLotSuppliers;
   private Map<String, String> getEventTypesForAgreement;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/TendersDBRetryable.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/TendersDBRetryable.java
@@ -1,0 +1,21 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import java.lang.annotation.*;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.transaction.TransactionException;
+import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
+
+/**
+ * Central retry configuration - see usage in {@link RetryableTendersDBDelegate}
+ */
+@Retryable(include = {TransientDataAccessException.class, TransactionException.class},
+    maxAttemptsExpression = "${config.retry.maxAttempts}",
+    backoff = @Backoff(delayExpression = "${config.retry.delay}",
+        multiplierExpression = "${config.retry.multiplier}"))
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TendersDBRetryable {
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/TendersDBDataException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/TendersDBDataException.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.cat.exception;
+
+/**
+ *
+ */
+public class TendersDBDataException extends RuntimeException {
+
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  public TendersDBDataException(final String msg) {
+    super(msg);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/LotSupplier.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/LotSupplier.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.agreements;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ *
+ */
+@Value
+@Builder
+@Jacksonized
+public class LotSupplier {
+
+  Organization organization;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Organization.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Organization.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.agreements;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ *
+ */
+@Value
+@Builder
+@Jacksonized
+public class Organization {
+
+  String id;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/OrganisationMapping.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/OrganisationMapping.java
@@ -1,0 +1,41 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.entity;
+
+import java.time.Instant;
+import javax.persistence.*;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+/**
+ *
+ */
+@Entity
+@Table(name = "organisation_mapping")
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class OrganisationMapping {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "organisation_mapping_id")
+  Integer id;
+
+  /**
+   * The Org service ID
+   */
+  @Column(name = "organisation_id")
+  String organisationId;
+
+  /**
+   * The sales platform ID
+   */
+  @Column(name = "external_organisation_id")
+  Integer externalOrganisationId;
+
+  @Column(name = "created_by", updatable = false)
+  String createdBy;
+
+  @Column(name = "created_at", updatable = false)
+  Instant createdAt;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementProject.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementProject.java
@@ -3,10 +3,8 @@ package uk.gov.crowncommercial.dts.scale.cat.model.entity;
 import java.time.Instant;
 import java.util.Set;
 import javax.persistence.*;
-import lombok.AccessLevel;
-import lombok.Data;
+import lombok.*;
 import lombok.experimental.FieldDefaults;
-import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
 
 /**
  * JPA entity representing a mapping between an internal ID, CA/Lot and Jaggaer internal project
@@ -15,7 +13,11 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
 @Entity
 @Table(name = "procurement_projects")
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@EqualsAndHashCode(exclude = "procurementEvents")
 public class ProcurementProject {
 
   @Id
@@ -41,6 +43,10 @@ public class ProcurementProject {
   @Column(name = "project_name")
   String projectName;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "organisation_mapping_id")
+  OrganisationMapping organisationMapping;
+
   @Column(name = "created_by", updatable = false)
   String createdBy;
 
@@ -52,30 +58,5 @@ public class ProcurementProject {
 
   @Column(name = "updated_at")
   Instant updatedAt;
-
-  /**
-   * Builds an instance from basic details
-   *
-   * @param agreementDetails
-   * @param externalProjectId The tender project id
-   * @param externalReferenceId The tender reference code
-   * @param projectName aka project title
-   * @param principal
-   * @return a procurement project
-   */
-  public static ProcurementProject of(AgreementDetails agreementDetails, String externalProjectId,
-      String externalReferenceId, String projectName, String principal) {
-    var procurementProject = new ProcurementProject();
-    procurementProject.setCaNumber(agreementDetails.getAgreementId());
-    procurementProject.setLotNumber(agreementDetails.getLotId());
-    procurementProject.setExternalProjectId(externalProjectId);
-    procurementProject.setExternalReferenceId(externalReferenceId);
-    procurementProject.setProjectName(projectName);
-    procurementProject.setCreatedBy(principal); // Or Jaggaer user ID?
-    procurementProject.setCreatedAt(Instant.now());
-    procurementProject.setUpdatedBy(principal); // Or Jaggaer user ID?
-    procurementProject.setUpdatedAt(Instant.now());
-    return procurementProject;
-  }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/OrganisationMappingRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/OrganisationMappingRepo.java
@@ -1,0 +1,25 @@
+package uk.gov.crowncommercial.dts.scale.cat.repo;
+
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
+
+/**
+ *
+ */
+@Repository
+public interface OrganisationMappingRepo extends JpaRepository<OrganisationMapping, Integer> {
+
+  Set<OrganisationMapping> findByOrganisationIdIn(Set<String> organisationIds);
+
+  /**
+   * TODO: Replace with Conclave lookup for Buyer organisation
+   *
+   * @param externalOrganisationId
+   * @return the organisation mapping for the given external org ID
+   */
+  Optional<OrganisationMapping> findByExternalOrganisationId(Integer externalOrganisationId);
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AgreementsService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AgreementsService.java
@@ -26,6 +26,7 @@ public class AgreementsService {
 
   private final WebClient agreementsServiceWebClient;
   private final AgreementsServiceAPIConfig agreementServiceAPIConfig;
+  private final WebclientWrapper webclientWrapper;
 
   public List<DataTemplate> getLotEventTypeDataTemplates(final String agreementId,
       final String lotId, final ViewEventType eventType) {
@@ -50,13 +51,10 @@ public class AgreementsService {
   public Set<LotSupplier> getLotSuppliers(final String agreementId, final String lotId) {
     var getLotSuppliersUri = agreementServiceAPIConfig.getGetLotSuppliers().get(KEY_URI_TEMPLATE);
 
-    var lotSuppliers = ofNullable(agreementsServiceWebClient.get()
-        .uri(getLotSuppliersUri, agreementId, lotId).retrieve().bodyToMono(LotSupplier[].class)
-        .block(ofSeconds(agreementServiceAPIConfig.getTimeoutDuration())))
-            .orElseThrow(() -> new AgreementsServiceApplicationException(
-                "Unexpected error retrieving RFI template from AS"));
+    var lotSuppliers = webclientWrapper.getOptionalResource(LotSupplier[].class,
+        agreementsServiceWebClient, getLotSuppliersUri, agreementId, lotId);
 
-    return Set.of(lotSuppliers);
+    return lotSuppliers.isPresent() ? Set.of(lotSuppliers.get()) : Set.of();
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/SupplierService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/SupplierService.java
@@ -1,0 +1,63 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static org.springframework.util.CollectionUtils.isEmpty;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.cat.exception.AgreementsServiceApplicationException;
+import uk.gov.crowncommercial.dts.scale.cat.exception.TendersDBDataException;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.CompanyData;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Supplier;
+import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
+
+/**
+ * Encapsulates operations related to suppliers
+ */
+@Service
+@RequiredArgsConstructor
+public class SupplierService {
+
+  private final RetryableTendersDBDelegate retryableTendersDBDelegate;
+  private final AgreementsService agreementsService;
+
+  /**
+   * Retrieves suppliers from the Agreements Service based on the CA and Lot and resolves each to a
+   * Jaggaer {@link Supplier} object via the organisation mapping table.
+   *
+   * @param agreementId
+   * @param lotId
+   * @return the list of suppliers for the given CA/Lot
+   * @throws AgreementsServiceApplicationException if no suppliers are found in AS for given CA/Lot
+   * @throws TendersDBDataException if not supplier org mappings are found in the mapping table
+   */
+  public List<Supplier> resolveSuppliers(final String agreementId, final String lotId) {
+
+    // Retrieve and verify AS suppliers
+    var lotSuppliers = agreementsService.getLotSuppliers(agreementId, lotId);
+    if (isEmpty(lotSuppliers)) {
+      throw new AgreementsServiceApplicationException(
+          "No Lot Suppliers found in AS for CA: '" + agreementId + "', Lot: '" + lotId + "'");
+    }
+
+    var supplierOrgIds =
+        lotSuppliers.stream().map(ls -> ls.getOrganization().getId()).collect(Collectors.toSet());
+
+    // Retrieve and verify Tenders DB org mappings
+    var supplierOrgMappings =
+        retryableTendersDBDelegate.findOrganisationMappingByOrganisationIdIn(supplierOrgIds);
+    if (isEmpty(supplierOrgMappings)) {
+      throw new TendersDBDataException("No supplier org mappings found in Tenders DB for CA: '"
+          + agreementId + "', Lot: '" + lotId + "'");
+    }
+
+    var supplierExternalIds =
+        supplierOrgMappings.stream().map(OrganisationMapping::getExternalOrganisationId)
+            .map(String::valueOf).collect(Collectors.toSet());
+
+    return supplierExternalIds.stream().map(id -> new Supplier(new CompanyData(id)))
+        .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/SupplierService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/SupplierService.java
@@ -1,10 +1,12 @@
 package uk.gov.crowncommercial.dts.scale.cat.service;
 
 import static org.springframework.util.CollectionUtils.isEmpty;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.cat.exception.AgreementsServiceApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.TendersDBDataException;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
@@ -17,6 +19,7 @@ import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SupplierService {
 
   private final RetryableTendersDBDelegate retryableTendersDBDelegate;
@@ -37,8 +40,8 @@ public class SupplierService {
     // Retrieve and verify AS suppliers
     var lotSuppliers = agreementsService.getLotSuppliers(agreementId, lotId);
     if (isEmpty(lotSuppliers)) {
-      throw new AgreementsServiceApplicationException(
-          "No Lot Suppliers found in AS for CA: '" + agreementId + "', Lot: '" + lotId + "'");
+      log.warn("No Lot Suppliers found in AS for CA: '{}', Lot: '{}'", agreementId, lotId);
+      return Collections.emptyList();
     }
 
     var supplierOrgIds =
@@ -48,8 +51,9 @@ public class SupplierService {
     var supplierOrgMappings =
         retryableTendersDBDelegate.findOrganisationMappingByOrganisationIdIn(supplierOrgIds);
     if (isEmpty(supplierOrgMappings)) {
-      throw new TendersDBDataException("No supplier org mappings found in Tenders DB for CA: '"
-          + agreementId + "', Lot: '" + lotId + "'");
+      log.warn("No supplier org mappings found in Tenders DB for CA: '{}', Lot: '{}'", agreementId,
+          lotId);
+      return Collections.emptyList();
     }
 
     var supplierExternalIds =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,8 @@ config:
         uriTemplate: /agreements/{agreement-id}
       getLotDetailsForAgreement:
         uriTemplate: /agreements/{agreement-id}/lots/{lot-id}
+      getLotSuppliers:
+        uriTemplate: /agreements/{agreement-id}/lots/{lot-id}/suppliers
       getLotEventTypeDataTemplates:
         uriTemplate: /agreements/{agreement-id}/lots/{lot-id}/event-types/{event-type}/data-templates
       getEventTypesForAgreement:

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementProject;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.ReturnSubUser.SubUser;
+import uk.gov.crowncommercial.dts.scale.cat.repo.OrganisationMappingRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementEventRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementProjectRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
@@ -79,6 +80,12 @@ class ProcurementEventServiceTest {
   @MockBean
   private ProcurementEventRepo procurementEventRepo;
 
+  @MockBean
+  private SupplierService supplierService;
+
+  @MockBean
+  private OrganisationMappingRepo organisationMappingRepo;
+
   @Autowired
   private ProcurementEventService procurementEventService;
 
@@ -101,7 +108,8 @@ class ProcurementEventServiceTest {
     createUpdateRfxResponse.setRfxId(RFX_ID);
     createUpdateRfxResponse.setRfxReferenceCode(RFX_REF_CODE);
 
-    var procurementProject = ProcurementProject.of(agreementDetails, "", "", "", "");
+    var procurementProject = ProcurementProject.builder()
+        .caNumber(agreementDetails.getAgreementId()).lotNumber(agreementDetails.getLotId()).build();
     var procurementEvent = ProcurementEvent.builder().build();
 
     // Mock behaviours
@@ -176,7 +184,8 @@ class ProcurementEventServiceTest {
     createUpdateRfxResponse.setRfxId(RFX_ID);
     createUpdateRfxResponse.setRfxReferenceCode(RFX_REF_CODE);
 
-    var procurementProject = ProcurementProject.of(agreementDetails, "", "", "", "");
+    var procurementProject = ProcurementProject.builder()
+        .caNumber(agreementDetails.getAgreementId()).lotNumber(agreementDetails.getLotId()).build();
     var procurementEvent = ProcurementEvent.builder().build();
 
     // Mock behaviours

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
@@ -67,14 +66,13 @@ class ProcurementProjectServiceTest {
   private static final String EVENT_OCID = "ocds-abc123-1";
   private static final Integer PROC_PROJECT_ID = 1;
   private static final String UPDATED_PROJECT_NAME = "New name";
-  private static final String BUYER_COMPANY_BRAVO_ID = "54321";
   private static final CreateEvent CREATE_EVENT = new CreateEvent();
   private static final OrganisationMapping ORG_MAPPING = new OrganisationMapping();
   private static final AgreementDetails AGREEMENT_DETAILS = new AgreementDetails();
   private static final Optional<SubUser> JAGGAER_USER =
       Optional.of(SubUser.builder().userId(JAGGAER_USER_ID).email(PRINCIPAL).build());
   private static final ReturnCompanyInfo BUYER_COMPANY_INFO =
-      ReturnCompanyInfo.builder().bravoId(BUYER_COMPANY_BRAVO_ID).build();
+      ReturnCompanyInfo.builder().bravoId(JAGGAER_BUYER_COMPANY_ID).build();
 
   @MockBean(answer = Answers.RETURNS_DEEP_STUBS)
   private WebClient jaggaerWebClient;
@@ -189,7 +187,6 @@ class ProcurementProjectServiceTest {
     // Mock behaviours
     when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
     when(userProfileService.resolveBuyerCompanyByEmail(PRINCIPAL)).thenReturn(BUYER_COMPANY_INFO);
-        .thenReturn(JAGGAER_BUYER_COMPANY_ID);
     when(organisationMappingRepo
         .findByExternalOrganisationId(Integer.valueOf(JAGGAER_BUYER_COMPANY_ID)))
             .thenReturn(Optional.of(ORG_MAPPING));
@@ -294,8 +291,17 @@ class ProcurementProjectServiceTest {
     // Verify
     verify(procurementProjectRepo).findById(PROC_PROJECT_ID);
 
-    assertTrue(Arrays.asList(ViewEventType.values()).containsAll(projectEventTypes),
-        "ViewEventType not superset of projectEventTypes");
+    // TODO : better way to compare ??
+    var defineEventTypes = projectEventTypes.stream()
+        .map(eventType -> eventType.getType().getValue()).collect(Collectors.joining(","));
+    var eventTypesDescription =
+        projectEventTypes.stream().map(EventType::getDescription).collect(Collectors.joining(","));
+    var expectedEventTypes = TestUtils.getEventTypes().stream()
+        .map(eventType -> eventType.getType().getValue()).collect(Collectors.joining(","));
+    var expectedEventTypesDescription = TestUtils.getEventTypes().stream()
+        .map(EventType::getDescription).collect(Collectors.joining(","));
+    assertEquals(defineEventTypes, expectedEventTypes);
+    assertEquals(eventTypesDescription, expectedEventTypesDescription);
   }
 
   @Test

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/RetryableTendersDBDelegateTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/RetryableTendersDBDelegateTest.java
@@ -17,6 +17,7 @@ import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.transaction.CannotCreateTransactionException;
 import uk.gov.crowncommercial.dts.scale.cat.config.RetryConfig;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementProject;
+import uk.gov.crowncommercial.dts.scale.cat.repo.OrganisationMappingRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementEventRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementProjectRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
@@ -33,6 +34,9 @@ class RetryableTendersDBDelegateTest {
 
   @MockBean
   private ProcurementEventRepo procurementEventRepo;
+
+  @MockBean
+  private OrganisationMappingRepo organisationMappingRepo;
 
   @Autowired
   private RetryableTendersDBDelegate retryableTendersDBDelegate;
@@ -62,7 +66,7 @@ class RetryableTendersDBDelegateTest {
     when(procurementProjectRepo.save(procurementProject)).thenThrow(transactionException,
         queryTimeoutException, transactionException, queryTimeoutException, transactionException);
 
-    ExhaustedRetryException exhaustedRetryEx = assertThrows(ExhaustedRetryException.class,
+    var exhaustedRetryEx = assertThrows(ExhaustedRetryException.class,
         () -> retryableTendersDBDelegate.save(procurementProject));
 
     assertTrue(exhaustedRetryEx.getMessage().startsWith("Retries exhausted"));

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/SupplierServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/SupplierServiceTest.java
@@ -1,0 +1,112 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.crowncommercial.dts.scale.cat.exception.AgreementsServiceApplicationException;
+import uk.gov.crowncommercial.dts.scale.cat.exception.TendersDBDataException;
+import uk.gov.crowncommercial.dts.scale.cat.model.agreements.LotSupplier;
+import uk.gov.crowncommercial.dts.scale.cat.model.agreements.Organization;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.CompanyData;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Supplier;
+import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
+
+/**
+ *
+ */
+@SpringBootTest(classes = {SupplierService.class}, webEnvironment = WebEnvironment.NONE)
+class SupplierServiceTest {
+
+  static final String AGREEMENT_NUMBER = "RM1234";
+  static final String LOT_NUMBER = "Lot 2";
+
+  static final String SUPPLIER_ORG_ID_1 = "1234567";
+  static final LotSupplier LOT_SUPPLIER_1 = LotSupplier.builder()
+      .organization(Organization.builder().id(SUPPLIER_ORG_ID_1).build()).build();
+  static final String SUPPLIER_ORG_ID_2 = "7654321";
+  static final LotSupplier LOT_SUPPLIER_2 = LotSupplier.builder()
+      .organization(Organization.builder().id(SUPPLIER_ORG_ID_2).build()).build();
+
+  static final Integer EXT_ORG_ID_1 = 2345678;
+  static final Integer EXT_ORG_ID_2 = 8765432;
+  static final OrganisationMapping ORG_MAPPING_1 = new OrganisationMapping();
+  static final OrganisationMapping ORG_MAPPING_2 = new OrganisationMapping();
+
+  static final Supplier EXT_SUPPLIER_1 =
+      new Supplier(new CompanyData(String.valueOf(EXT_ORG_ID_1)));
+  static final Supplier EXT_SUPPLIER_2 =
+      new Supplier(new CompanyData(String.valueOf(EXT_ORG_ID_2)));
+
+  @MockBean
+  private AgreementsService agreementsService;
+
+  @MockBean
+  private RetryableTendersDBDelegate retryableTendersDBDelegate;
+
+  @Autowired
+  private SupplierService supplierService;
+
+  @BeforeAll
+  static void beforeClass() {
+    ORG_MAPPING_1.setOrganisationId(SUPPLIER_ORG_ID_1);
+    ORG_MAPPING_1.setExternalOrganisationId(EXT_ORG_ID_1);
+    ORG_MAPPING_2.setOrganisationId(SUPPLIER_ORG_ID_1);
+    ORG_MAPPING_2.setExternalOrganisationId(EXT_ORG_ID_2);
+  }
+
+  @Test
+  void testResolveSuppliers() throws Exception {
+    when(agreementsService.getLotSuppliers(AGREEMENT_NUMBER, LOT_NUMBER))
+        .thenReturn(Set.of(LOT_SUPPLIER_1, LOT_SUPPLIER_2));
+
+    when(retryableTendersDBDelegate
+        .findOrganisationMappingByOrganisationIdIn(Set.of(SUPPLIER_ORG_ID_1, SUPPLIER_ORG_ID_2)))
+            .thenReturn(Set.of(ORG_MAPPING_1, ORG_MAPPING_2));
+
+    var suppliers = supplierService.resolveSuppliers(AGREEMENT_NUMBER, LOT_NUMBER);
+
+    assertEquals(Set.of(EXT_SUPPLIER_1, EXT_SUPPLIER_2), Set.copyOf(suppliers));
+
+    verify(agreementsService).getLotSuppliers(AGREEMENT_NUMBER, LOT_NUMBER);
+    verify(retryableTendersDBDelegate).findOrganisationMappingByOrganisationIdIn(anySet());
+  }
+
+  @Test
+  void testResolveSuppliersNonFoundInAS() throws Exception {
+    when(agreementsService.getLotSuppliers(AGREEMENT_NUMBER, LOT_NUMBER)).thenReturn(Set.of());
+
+    var asAppEx = assertThrows(AgreementsServiceApplicationException.class,
+        () -> supplierService.resolveSuppliers(AGREEMENT_NUMBER, LOT_NUMBER));
+    assertEquals(
+        "Agreements Service application exception, Code: [N/A], Message: [No Lot Suppliers found in AS for CA: '"
+            + AGREEMENT_NUMBER + "', Lot: '" + LOT_NUMBER + "']",
+        asAppEx.getMessage());
+  }
+
+  @Test
+  void testResolveSuppliersNoOrgMappings() throws Exception {
+    when(agreementsService.getLotSuppliers(AGREEMENT_NUMBER, LOT_NUMBER))
+        .thenReturn(Set.of(LOT_SUPPLIER_1, LOT_SUPPLIER_2));
+
+    when(retryableTendersDBDelegate
+        .findOrganisationMappingByOrganisationIdIn(Set.of(SUPPLIER_ORG_ID_1, SUPPLIER_ORG_ID_2)))
+            .thenReturn(Set.of());
+
+    var tendersDBDataException = assertThrows(TendersDBDataException.class,
+        () -> supplierService.resolveSuppliers(AGREEMENT_NUMBER, LOT_NUMBER));
+
+    assertEquals("No supplier org mappings found in Tenders DB for CA: '" + AGREEMENT_NUMBER
+        + "', Lot: '" + LOT_NUMBER + "'", tendersDBDataException.getMessage());
+  }
+
+}


### PR DESCRIPTION
### JIRA link ###
https://crowncommercialservice.atlassian.net/browse/SCC-441 (supplier mappings)
https://crowncommercialservice.atlassian.net/browse/SCC-440 / https://crowncommercialservice.atlassian.net/browse/SCAT-1849 (procurement project buyer organisation)

### Change description ###

1. Replace the temporary, hardcoded list of sales platform supplier IDs with a lookup to the Agreements Service and resolution of sales platform supplier org IDs via the new organisation mappings table.
2. Resolves the buyer organisation via the same org mapping table and sets this on the procurement project record.

### Does this PR introduce a breaking change?
No