### PR TITLE
Swith to Jaggaer self-service for user profile lkp

### DIFF
--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -43,6 +43,10 @@ data "aws_ssm_parameter" "jaggaer_token_url" {
   name = "/cat/${var.environment}/jaggaer-token-url"
 }
 
+data "aws_ssm_parameter" "jaggaer_self_service_id" {
+  name = "/cat/${var.environment}/jaggaer-self-service-id"
+}
+
 data "aws_ssm_parameter" "auth_server_jwk_set_uri" {
   name = "/cat/${var.environment}/auth-server-jwk-set-uri"
 }
@@ -62,6 +66,7 @@ resource "cloudfoundry_app" "cat_service" {
     "spring.security.oauth2.client.registration.jaggaer.client-secret" : data.aws_ssm_parameter.jaggaer_client_secret.value
     "spring.security.oauth2.client.provider.jaggaer.token-uri" : data.aws_ssm_parameter.jaggaer_token_url.value
     "config.external.jaggaer.baseUrl" : data.aws_ssm_parameter.jaggaer_base_url.value
+    "config.external.jaggaer.self-service-id" : data.aws_ssm_parameter.jaggaer_self_service_id.value
     "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" : data.aws_ssm_parameter.auth_server_jwk_set_uri.value
     "config.external.agreements-service.baseUrl" : data.aws_ssm_parameter.agreements_service_base_url.value
   }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/UserProfileService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/UserProfileService.java
@@ -3,7 +3,6 @@ package uk.gov.crowncommercial.dts.scale.cat.service;
 import static java.util.Optional.ofNullable;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import java.time.Duration;
-import java.util.Set;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -43,12 +42,12 @@ public class UserProfileService {
           .build(jaggaerSubUserProfileCacheLoader());
 
   @SneakyThrows
-  public String resolveJaggaerUserId(String principal) {
+  public String resolveJaggaerUserId(final String principal) {
     return jaggaerSubUserProfileCache.get(principal).getSecond().getUserId();
   }
 
   @SneakyThrows
-  public String resolveJaggaerBuyerCompanyId(String principal) {
+  public String resolveJaggaerBuyerCompanyId(final String principal) {
     return jaggaerSubUserProfileCache.get(principal).getFirst().getBravoId();
   }
 
@@ -56,7 +55,7 @@ public class UserProfileService {
     return new CacheLoader<>() {
 
       @Override
-      public Pair<ReturnCompanyInfo, SubUser> load(String principal) throws Exception {
+      public Pair<ReturnCompanyInfo, SubUser> load(final String principal) throws Exception {
         var getBuyerCompanyProfile = jaggaerAPIConfig.getGetBuyerCompanyProfile();
         var principalPlaceholder = getBuyerCompanyProfile.get("principalPlaceholder");
         var endpoint =
@@ -82,7 +81,7 @@ public class UserProfileService {
         }
         var returnCompanyData = getCompanyDataResponse.getReturnCompanyData().stream().findFirst()
             .orElseThrow(() -> INVALID_COMPANY_PROFILE_DATA_EXCEPTION);
-        Set<SubUser> subUsers = returnCompanyData.getReturnSubUser().getSubUsers();
+        var subUsers = returnCompanyData.getReturnSubUser().getSubUsers();
 
         var subUser = subUsers.stream().filter(su -> principal.equalsIgnoreCase(su.getEmail()))
             .findFirst()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,15 +67,15 @@ config:
         # CA-Lot-BuyerOrg e.g. RM1234-Lot1a-CCS
         defaultTitleFormat: "%s-%s-%s"
         endpoint: /esop/jint/api/public/ja/v1/projects
-        templateId: project_609
+        templateId: tender_49
       createRfx:
         # ProjectName-EventType e.g. RM1234-Lot1a-CCS-RFP
         defaultTitleFormat: "%s-%s"
         endpoint: /esop/jint/api/public/ja/v1/rfxs/
-        templateId: itt_543
+        templateId: itt_445
       getBuyerCompanyProfile:
         # endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==GURU;SUBUSERLOGIN=={{PRINCIPAL}}
-        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==GURU
+        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==BUYER;BRAVOID==${config.external.jaggaer.self-service-id}
         principalPlaceholder: "{{PRINCIPAL}}"
       exportRfx:
         endpoint: /esop/jint/api/public/ja/v1/rfxs/{id}


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-1986

### Change description ###
Updates the user profile service to query the Sales platform self-service area, including update of project and event template IDs and direct lookup in self-service area via REST API query filter change (using self-service ID stored in SSM)

@adrianmilne This should work for you already as you have a profile on the self-service side. 
@sudhakar-reddy-konda - I will request a new profile for you

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (assuming a user profile exists on self-service side)

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
