### PR TITLE
Feature/scat 2381 put users

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
@@ -66,4 +66,14 @@ public class ProjectsController extends AbstractRestController {
     return procurementProjectService.getProjectTeamMembers(procId);
   }
 
+  @PutMapping("/{proc-id}/users/{user-id}")
+  public TeamMember addProjectUser(@PathVariable("proc-id") final Integer procId,
+      @PathVariable("user-id") final String userId, final JwtAuthenticationToken authentication) {
+
+    log.info("addProjectUser invoked on behalf of principal: {}",
+        getPrincipalFromJwt(authentication));
+
+    return procurementProjectService.addProjectTeamMember(procId, userId);
+  }
+
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
@@ -34,9 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
-import uk.gov.crowncommercial.dts.scale.cat.model.generated.ContactPoint1;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.ProcurementProjectName;
-import uk.gov.crowncommercial.dts.scale.cat.model.generated.TeamMember;
 import uk.gov.crowncommercial.dts.scale.cat.service.ProcurementProjectService;
 import uk.gov.crowncommercial.dts.scale.cat.util.TestUtils;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
@@ -55,7 +53,6 @@ class ProjectsControllerTest {
   private static final String ORG = "CCS";
   private static final String PROJ_NAME = CA_NUMBER + '-' + LOT_NUMBER + '-' + ORG;
   private static final String EVENT_OCID = "ocds-abc123-1";
-  private static final String USER_NAME = "Jim Beam";
   private static final Integer PROC_PROJECT_ID = 1;
 
   private final AgreementDetails agreementDetails = new AgreementDetails();
@@ -215,25 +212,19 @@ class ProjectsControllerTest {
 
   @Test
   void getProjectUsers_200_OK() throws Exception {
-
-    TeamMember teamMember = new TeamMember();
-    ContactPoint1 contact = new ContactPoint1();
-    contact.setEmail(PRINCIPAL);
-    contact.setName(USER_NAME);
-    teamMember.setId(PRINCIPAL);
-    teamMember.setContact(contact);
+    ;
 
     when(procurementProjectService.getProjectTeamMembers(PROC_PROJECT_ID))
-        .thenReturn(Arrays.asList(teamMember));
+        .thenReturn(Arrays.asList(TestUtils.getTeamMember()));
 
     mockMvc
         .perform(get("/tenders/projects/" + PROC_PROJECT_ID + "/users")
             .with(validJwtReqPostProcessor).accept(APPLICATION_JSON))
         .andDo(print()).andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON)).andExpect(jsonPath("$.size()").value(1))
-        .andExpect(jsonPath("$[0].id", is(PRINCIPAL)))
-        .andExpect(jsonPath("$[0].contact.name", is(USER_NAME)))
-        .andExpect(jsonPath("$[0].contact.email", is(PRINCIPAL)));
+        .andExpect(jsonPath("$[0].id", is(TestUtils.USERID)))
+        .andExpect(jsonPath("$[0].contact.name", is(TestUtils.USER_NAME)))
+        .andExpect(jsonPath("$[0].contact.email", is(TestUtils.USERID)));
   }
 
   @Test
@@ -270,5 +261,24 @@ class ProjectsControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is("500 INTERNAL_SERVER_ERROR"))).andExpect(
             jsonPath("$.errors[0].title", is("An error occurred invoking an upstream service")));
   }
+
+  @Test
+  void addProjectUser_200_OK() throws Exception {
+
+    when(procurementProjectService.addProjectTeamMember(PROC_PROJECT_ID, TestUtils.USERID))
+        .thenReturn(TestUtils.getTeamMember());
+
+    mockMvc
+        .perform(put("/tenders/projects/" + PROC_PROJECT_ID + "/users/" + TestUtils.USERID)
+            .with(validJwtReqPostProcessor).contentType(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.id", is(TestUtils.USERID)))
+        .andExpect(jsonPath("$.contact.name", is(TestUtils.USER_NAME)))
+        .andExpect(jsonPath("$.contact.email", is(TestUtils.USERID)));
+
+    verify(procurementProjectService).addProjectTeamMember(PROC_PROJECT_ID, TestUtils.USERID);
+  }
+
 }
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TestUtils.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TestUtils.java
@@ -2,10 +2,11 @@ package uk.gov.crowncommercial.dts.scale.cat.util;
 
 import java.util.Arrays;
 import java.util.List;
-
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.ProjectEventType;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.ContactPoint1;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.DefineEventType;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.EventType;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.TeamMember;
 
 public class TestUtils {
 
@@ -14,6 +15,9 @@ public class TestUtils {
   public static final String CAPABILITY_ASSESSMENT = "Capability Assessment";
   public static final String DIRECT_AWARD = "Direct Award";
   public static final String FURTHER_COMPETITION = "Further Competition";
+
+  public static final String USER_NAME = "Jim Beam";
+  public static final String USERID = "jbeam@ccs.org.uk";
 
   public static EventType getEventType(final DefineEventType defineEventType,
       final String description, final boolean preMarketActivity) {
@@ -49,5 +53,15 @@ public class TestUtils {
         getProjectEventType("CA", CAPABILITY_ASSESSMENT, true),
         getProjectEventType("DA", DIRECT_AWARD, false),
         getProjectEventType("FC", FURTHER_COMPETITION, false)};
+  }
+
+  public static TeamMember getTeamMember() {
+    TeamMember teamMember = new TeamMember();
+    ContactPoint1 contact = new ContactPoint1();
+    contact.setEmail(USERID);
+    contact.setName(USER_NAME);
+    teamMember.setId(USERID);
+    teamMember.setContact(contact);
+    return teamMember;
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-2381


### Change description ###
Added `/tenders/projects/{proc-id}/users/{user-id}` endpoint

This will add the supplied user (userId is email) to the ProjectTeam. This is not the complete story as there will be updates following an API update (to cater for EMail Recipients and Project Owner) - which is why there are no Service tests, and why there is a slight naming mismatch between the controller (addProjectUser) and the service (addProjectTeamMember) for now.

Getting this in should unblock the UI guys for now though.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No

**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
