### PR TITLE
Move Tenders API to public domain

### DIFF
--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -112,3 +112,9 @@ resource "cloudfoundry_route" "cat_service" {
     port = 8080
   }
 }
+
+# Bind to nginx IP Router UPS
+resource "cloudfoundry_route_service_binding" "cat_service" {
+  service_instance = data.cloudfoundry_user_provided_service.ip_router.id
+  route            = cloudfoundry_route.cat_service.id
+}

--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -8,7 +8,7 @@ data "cloudfoundry_space" "space" {
 }
 
 data "cloudfoundry_domain" "domain" {
-  name = "apps.internal"
+  name = "london.cloudapps.digital"
 }
 
 data "cloudfoundry_service_instance" "tenders_database" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/CON-1729


### Change description ###
To permit external connections to the Tenders API, move it to the public domain with nginx IP auth in front of it.


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No - see corresponding UI PR which must be merged and deployed immediately after this

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
