### PR TITLE
Move Tenders API to public domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - "$HOME/.m2"
 branches:
   only:
-    - "/^(feature|bugfix)\\/(SCC|SCAT)-[0-9]+.*$/"
+    - "/^(feature|bugfix)\\/(SCC|SCAT|CON)-[0-9]+.*$/"
     - "/^(release)\\/.*$/"
     - develop
     - main
@@ -26,7 +26,7 @@ deploy:
     script: CF_ENVIRONMENT=sbx2 bash ./deploy.sh
     on:
       all_branches: true
-      condition: "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} =~ ^(feature|bugfix)\\/(SCC|SCAT)-[0-9]+.*$"
+      condition: "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} =~ ^(feature|bugfix)\\/(SCC|SCAT|CON)-[0-9]+.*$"
 
   # DEVELOP
   - provider: script

--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -77,8 +77,8 @@ resource "cloudfoundry_app" "cat_service" {
     "config.external.jaggaer.self-service-id" : data.aws_ssm_parameter.jaggaer_self_service_id.value
     "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" : data.aws_ssm_parameter.auth_server_jwk_set_uri.value
     "config.external.agreements-service.baseUrl" : data.aws_ssm_parameter.agreements_service_base_url.value
-    "config.external.conclave.wrapper-api-base-url" : data.aws_ssm_parameter.conclave_wrapper_api_base_url.value
-    "config.external.conclave.wrapper-api-key" : data.aws_ssm_parameter.conclave_wrapper_api_key.value
+    "config.external.conclave-wrapper.baseUrl" : data.aws_ssm_parameter.conclave_wrapper_api_base_url.value
+    "config.external.conclave-wrapper.apiKey" : data.aws_ssm_parameter.conclave_wrapper_api_key.value
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"

--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -8,7 +8,7 @@ data "cloudfoundry_space" "space" {
 }
 
 data "cloudfoundry_domain" "domain" {
-  name = "apps.internal"
+  name = "london.cloudapps.digital"
 }
 
 data "cloudfoundry_service_instance" "tenders_database" {
@@ -111,4 +111,10 @@ resource "cloudfoundry_route" "cat_service" {
     app  = cloudfoundry_app.cat_service.id
     port = 8080
   }
+}
+
+# Bind to nginx IP Router UPS
+resource "cloudfoundry_route_service_binding" "cat_service" {
+  service_instance = data.cloudfoundry_user_provided_service.ip_router.id
+  route            = cloudfoundry_route.cat_service.id
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-    		<groupId>org.springframework.boot</groupId>
-    		<artifactId>spring-boot-starter-validation</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.retry</groupId>
@@ -146,6 +146,7 @@
 				<version>${openapi-generator.version}</version>
 				<executions>
 					<execution>
+						<id>tenders-api</id>
 						<goals>
 							<goal>generate</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,36 @@
 							</configOptions>
 						</configuration>
 					</execution>
+					<execution>
+						<id>conclave-wrapper-api</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<inputSpec>https://tst.api.crowncommercial.gov.uk/user-profiles/swagger/v1/swagger.json</inputSpec>
+							<generatorName>spring</generatorName>
+							<generateModels>true</generateModels>
+							<generateSupportingFiles>false</generateSupportingFiles>
+							<generateApis>false</generateApis>
+							<generateModelTests>false</generateModelTests>
+							<modelPackage>uk.gov.crowncommercial.dts.scale.cat.model.conclave-wrapper.generated</modelPackage>
+							<skipValidateSpec>false</skipValidateSpec>
+							<strictSpec>true</strictSpec>
+							<importMappings>Error=uk.gov.crowncommercial.dts.scale.cat.model.ApiError</importMappings>
+							<verbose>false</verbose>
+							<configOptions>
+								<sourceFolder>src/gen/java/main</sourceFolder>
+								<useBeanValidation>true</useBeanValidation>
+								<performBeanValidation>true</performBeanValidation>
+								<dateLibrary>java8</dateLibrary>
+								<hideGenerationTimestamp>true</hideGenerationTimestamp>
+								<openApiNullable>false</openApiNullable>
+								<useOptional>true</useOptional>
+							</configOptions>
+						</configuration>
+					</execution>
 				</executions>
-			</plugin>
+			</plugin> 
 		</plugins>
 	</build>
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveAPIConfig.java
@@ -18,6 +18,8 @@ public class ConclaveAPIConfig {
   private String baseUrl;
   private String apiKey;
   private Integer timeoutDuration;
+  private String buyerRoleKey;
+  private String supplierRoleKey;
   private Map<String, String> getUser;
   private Map<String, String> getUserContacts;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveAPIConfig.java
@@ -1,0 +1,23 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import lombok.Data;
+
+/**
+ *
+ */
+@Configuration
+@ConfigurationProperties(prefix = "config.external.conclave-wrapper", ignoreUnknownFields = true)
+@Data
+public class ConclaveAPIConfig {
+
+  public static final String KEY_URI_TEMPLATE = "uriTemplate";
+
+  private String baseUrl;
+  private String apiKey;
+  private Integer timeoutDuration;
+  private Map<String, String> getUser;
+  private Map<String, String> getUserContacts;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveClientConfig.java
@@ -1,0 +1,35 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.JettyClientHttpConnector;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.web.reactive.function.client.WebClient;
+import lombok.RequiredArgsConstructor;
+
+/**
+ *
+ */
+@Configuration
+@RequiredArgsConstructor
+public class ConclaveClientConfig {
+
+  private final ConclaveAPIConfig conclaveAPIConfig;
+
+  @Bean("conclaveWebClient")
+  public WebClient webClient(final OAuth2AuthorizedClientManager authorizedClientManager) {
+    var client = new HttpClient(new SslContextFactory.Client(true));
+
+    ClientHttpConnector jettyHttpClientConnector = new JettyClientHttpConnector(client);
+
+    return WebClient.builder().clientConnector(jettyHttpClientConnector)
+        .baseUrl(conclaveAPIConfig.getBaseUrl()).defaultHeader(ACCEPT, APPLICATION_JSON_VALUE)
+        .defaultHeader("x-api-key", conclaveAPIConfig.getApiKey()).build();
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
@@ -15,6 +15,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.TenderStatus;
 public class JaggaerAPIConfig {
 
   public static final String ENDPOINT = "endpoint";
+  public static final String PRINCIPAL_PLACEHOLDER = "{{PRINCIPAL}}";
 
   private String baseUrl;
   private String headerValueWWWAuthenticate;
@@ -28,5 +29,7 @@ public class JaggaerAPIConfig {
   private Map<String, String> createRfx;
   private Map<String, String> getBuyerCompanyProfile;
   private Map<String, String> exportRfx;
+  private Map<String, String> getSupplierCompanyProfile;
+  private Map<String, String> getSupplierSubUserProfile;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerAPIConfig.java
@@ -24,6 +24,7 @@ public class JaggaerAPIConfig {
   private Boolean addDivisionToProjectTeam;
   private Long tokenExpirySeconds;
   private Map<String, String> createProject;
+  private Map<String, String> getProject;
   private Map<String, String> createRfx;
   private Map<String, String> getBuyerCompanyProfile;
   private Map<String, String> exportRfx;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/OAuth2Config.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/OAuth2Config.java
@@ -22,6 +22,10 @@ public class OAuth2Config extends WebSecurityConfigurerAdapter {
   private final UnauthorizedResponseDecorator unauthorizedResponseDecorator;
   private final AccessDeniedResponseDecorator accessDeniedResponseDecorator;
 
+  // TODO: Move to SSM.
+  private static final String[] CONCLAVE_ROLES =
+      new String[] {"CAT_USER", "CAT_ADMINISTRATOR", "ACCESS_CAT", "CAT_USER_LOGIN_DIRECTOR"};
+
   @Override
   protected void configure(final HttpSecurity http) throws Exception {
 
@@ -30,8 +34,8 @@ public class OAuth2Config extends WebSecurityConfigurerAdapter {
     // @formatter:off
     http.authorizeRequests(authz ->
       authz
-        .antMatchers("/tenders/**").hasAnyAuthority("CAT_USER", "CAT_ADMINISTRATOR", "ACCESS_CAT")
-        .antMatchers("/error/**").hasAnyAuthority("CAT_USER", "CAT_ADMINISTRATOR", "ACCESS_CAT")
+        .antMatchers("/tenders/**").hasAnyAuthority(CONCLAVE_ROLES)
+        .antMatchers("/error/**").hasAnyAuthority(CONCLAVE_ROLES)
         .anyRequest().denyAll()
     )
     .csrf(CsrfConfigurer::disable)

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/GlobalErrorHandler.java
@@ -1,9 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.cat.controller;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.*;
 import java.util.Arrays;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
@@ -22,9 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.cat.config.Constants;
 import uk.gov.crowncommercial.dts.scale.cat.config.OAuth2Config;
-import uk.gov.crowncommercial.dts.scale.cat.exception.MalformedJwtException;
-import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
-import uk.gov.crowncommercial.dts.scale.cat.exception.UpstreamServiceException;
+import uk.gov.crowncommercial.dts.scale.cat.exception.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.ApiError;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.Errors;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
@@ -82,6 +77,26 @@ public class GlobalErrorHandler implements ErrorController {
     return ResponseEntity.status(UNAUTHORIZED)
         .header(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticateBearerInvalidJWT)
         .body(tendersAPIModelUtils.buildErrors(Arrays.asList(apiError)));
+  }
+
+  @ResponseStatus(FORBIDDEN)
+  @ExceptionHandler(AuthorisationFailureException.class)
+  public Errors handleUnauthorisedException(final AuthorisationFailureException exception) {
+
+    log.error("UnauthorisedException", exception);
+
+    var apiError = new ApiError(FORBIDDEN.toString(), exception.getMessage(), "");
+    return tendersAPIModelUtils.buildErrors(Arrays.asList(apiError));
+  }
+
+  @ResponseStatus(CONFLICT)
+  @ExceptionHandler(UserRolesConflictException.class)
+  public Errors handleUserRolesConflictException(final UserRolesConflictException exception) {
+
+    log.error("UserRolesConflictException", exception);
+
+    var apiError = new ApiError(CONFLICT.toString(), exception.getMessage(), "");
+    return tendersAPIModelUtils.buildErrors(Arrays.asList(apiError));
   }
 
   @ResponseStatus(NOT_FOUND)

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
@@ -55,4 +55,15 @@ public class ProjectsController extends AbstractRestController {
 
     return procurementProjectService.getProjectEventTypes(procId);
   }
+
+  @GetMapping("/{proc-id}/users")
+  public Collection<TeamMember> getProjectUsers(@PathVariable("proc-id") final Integer procId,
+      final JwtAuthenticationToken authentication) {
+
+    log.info("getProjectUsers invoked on behalf of principal: {}",
+        getPrincipalFromJwt(authentication));
+
+    return procurementProjectService.getProjectTeamMembers(procId);
+  }
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
@@ -66,4 +66,14 @@ public class ProjectsController extends AbstractRestController {
     return procurementProjectService.getProjectTeamMembers(procId);
   }
 
+  @PutMapping("/{proc-id}/users/{user-id}")
+  public TeamMember addProjectUser(@PathVariable("proc-id") final Integer procId,
+      @PathVariable("user-id") final String userId, final JwtAuthenticationToken authentication) {
+
+    log.info("addProjectUser invoked on behalf of principal: {}",
+        getPrincipalFromJwt(authentication));
+
+    return procurementProjectService.addProjectTeamMember(procId, userId);
+  }
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersController.java
@@ -5,11 +5,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.google.common.base.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.crowncommercial.dts.scale.cat.exception.AuthorisationFailureException;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.GetUserResponse;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.ViewEventType;
+import uk.gov.crowncommercial.dts.scale.cat.service.ProfileManagementService;
 
 /**
  * Tenders ('Base Data' tag in YAML)
@@ -20,6 +25,8 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.ViewEventType;
 @Slf4j
 public class TendersController extends AbstractRestController {
 
+  private final ProfileManagementService profileManagementService;
+
   @GetMapping("/event-types")
   public Collection<ViewEventType> listProcurementEventTypes(
       final JwtAuthenticationToken authentication) {
@@ -28,6 +35,23 @@ public class TendersController extends AbstractRestController {
         getPrincipalFromJwt(authentication));
 
     return Arrays.asList(ViewEventType.values());
+  }
+
+  @GetMapping("/users/{user-id}")
+  public GetUserResponse getUser(@PathVariable("user-id") final String userId,
+      final JwtAuthenticationToken authentication) {
+
+    var principal = getPrincipalFromJwt(authentication);
+
+    log.info("getUserRoles invoked on behalf of principal: {} for user-id: {}", principal, userId);
+
+    if (!Objects.equal(principal, userId)) {
+      // CON-1680-AC3
+      throw new AuthorisationFailureException(
+          "Authenticated user does not match requested user-id");
+    }
+
+    return new GetUserResponse().roles(profileManagementService.getUserRoles(userId));
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/AuthorisationFailureException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/AuthorisationFailureException.java
@@ -1,0 +1,19 @@
+package uk.gov.crowncommercial.dts.scale.cat.exception;
+
+/**
+ * General purpose exception to be thrown by the application's business logic code when an
+ * unauthorised operation is attempted, for example getting role information for a different user to
+ * the currently authenticated one. Should result in a 403 being returned.
+ */
+public class AuthorisationFailureException extends RuntimeException {
+
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  public AuthorisationFailureException(final String msg) {
+    super(msg);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/ConclaveApplicationException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/ConclaveApplicationException.java
@@ -1,0 +1,19 @@
+package uk.gov.crowncommercial.dts.scale.cat.exception;
+
+import java.util.Optional;
+
+/**
+ * Conclave application exception
+ */
+public class ConclaveApplicationException extends UpstreamServiceException {
+
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  public ConclaveApplicationException(final String msg) {
+    super("Conclave", Optional.empty(), msg);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/UnhandledEdgeCaseException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/UnhandledEdgeCaseException.java
@@ -11,4 +11,8 @@ public class UnhandledEdgeCaseException extends RuntimeException {
     super(msg);
   }
 
+  public UnhandledEdgeCaseException(final String msg, final Throwable cause) {
+    super(msg, cause);
+  }
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/UnhandledEdgeCaseException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/UnhandledEdgeCaseException.java
@@ -1,0 +1,14 @@
+package uk.gov.crowncommercial.dts.scale.cat.exception;
+
+public class UnhandledEdgeCaseException extends RuntimeException {
+
+  /**
+  *
+  */
+  private static final long serialVersionUID = 1L;
+
+  public UnhandledEdgeCaseException(final String msg) {
+    super(msg);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/UserRolesConflictException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/UserRolesConflictException.java
@@ -1,0 +1,18 @@
+package uk.gov.crowncommercial.dts.scale.cat.exception;
+
+/**
+ * Thrown when a principal's roles conflict in source systems. Should result in a 409 being
+ * returned.
+ */
+public class UserRolesConflictException extends RuntimeException {
+
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  public UserRolesConflictException(final String msg) {
+    super(msg);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/EmailRecipient.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/EmailRecipient.java
@@ -4,11 +4,19 @@ import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+/**
+*
+*/
 @Value
 @Builder
 @Jacksonized
-public class ProjectOwner {
+public class EmailRecipient {
 
-  String id;
-
+  User user;
+  String email;
+  String division;
+  String profile;
+  Integer objectVisibility;
+  Integer divisionId;
+  Integer profileId;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/EmailRecipientList.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/EmailRecipientList.java
@@ -1,14 +1,19 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.jaggaer;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+/**
+*
+*/
 @Value
 @Builder
 @Jacksonized
-public class ProjectOwner {
+public class EmailRecipientList {
 
-  String id;
-
+  List<EmailRecipient> emailRecipient;
 }
+
+

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ExportRfxResponse.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ExportRfxResponse.java
@@ -12,5 +12,6 @@ import lombok.experimental.FieldDefaults;
 public class ExportRfxResponse {
 
   RfxSetting rfxSetting;
+  EmailRecipientList emailRecipientList;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ReturnCompanyInfo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ReturnCompanyInfo.java
@@ -1,11 +1,15 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.jaggaer;
 
-import lombok.Data;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  *
  */
-@Data
+@Value
+@Builder
+@Jacksonized
 public class ReturnCompanyInfo {
 
   String bravoId;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ReturnSubUser.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ReturnSubUser.java
@@ -21,6 +21,8 @@ public class ReturnSubUser {
     String email;
     String login;
     String userId;
+    String phoneNumber;
+    String mobilePhoneNumber;
 
   }
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ReturnSubUser.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/ReturnSubUser.java
@@ -2,9 +2,10 @@ package uk.gov.crowncommercial.dts.scale.cat.model.jaggaer;
 
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
-import lombok.experimental.FieldDefaults;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  *
@@ -12,8 +13,9 @@ import lombok.experimental.FieldDefaults;
 @Data
 public class ReturnSubUser {
 
-  @Data
-  @FieldDefaults(level = AccessLevel.PRIVATE)
+  @Value
+  @Builder
+  @Jacksonized
   public static class SubUser {
 
     String name;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/Tender.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/jaggaer/Tender.java
@@ -2,9 +2,11 @@ package uk.gov.crowncommercial.dts.scale.cat.model.jaggaer;
 
 import lombok.Builder;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 @Value
 @Builder
+@Jacksonized
 public class Tender {
 
   String tenderCode;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ConclaveService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ConclaveService.java
@@ -1,0 +1,57 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Optional.ofNullable;
+import static uk.gov.crowncommercial.dts.scale.cat.config.AgreementsServiceAPIConfig.KEY_URI_TEMPLATE;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.cat.config.ConclaveAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.exception.ConclaveApplicationException;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserContactInfoList;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserProfileResponseInfo;
+
+/**
+ * Conclave Service.
+ */
+@Service
+@RequiredArgsConstructor
+public class ConclaveService {
+
+  private final WebClient conclaveWebClient;
+  private final ConclaveAPIConfig conclaveAPIConfig;
+
+  /**
+   * Get User Profile details.
+   *
+   * @param userId
+   * @return
+   */
+  public UserProfileResponseInfo getUserProfile(final String userId) {
+
+    final var getUserTemplateURI = conclaveAPIConfig.getGetUser().get(KEY_URI_TEMPLATE);
+
+    return ofNullable(conclaveWebClient.get().uri(getUserTemplateURI, userId).retrieve()
+        .bodyToMono(UserProfileResponseInfo.class)
+        .block(ofSeconds(conclaveAPIConfig.getTimeoutDuration())))
+            .orElseThrow(() -> new ConclaveApplicationException(
+                "Unexpected error retrieving User profile from Conclave"));
+  }
+
+  /**
+   * Get User Contact details.
+   *
+   * @param userId
+   * @return
+   */
+  public UserContactInfoList getUserContacts(final String userId) {
+
+    final var getUserTemplateURI = conclaveAPIConfig.getGetUserContacts().get(KEY_URI_TEMPLATE);
+
+    return ofNullable(conclaveWebClient.get().uri(getUserTemplateURI, userId).retrieve()
+        .bodyToMono(UserContactInfoList.class)
+        .block(ofSeconds(conclaveAPIConfig.getTimeoutDuration())))
+            .orElseThrow(() -> new ConclaveApplicationException(
+                "Unexpected error retrieving User contacts from Conclave"));
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementService.java
@@ -1,0 +1,89 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static java.lang.String.format;
+import java.util.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.crowncommercial.dts.scale.cat.config.ConclaveAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
+import uk.gov.crowncommercial.dts.scale.cat.exception.UserRolesConflictException;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.RolePermissionInfo;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.GetUserResponse.RolesEnum;
+
+/**
+ * Coordinating service for Conclave / Jaggaer Org and User profile operations
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProfileManagementService {
+
+  static final String SYSID_CONCLAVE = "Conclave";
+  static final String SYSID_JAGGAER = "Jaggaer";
+  static final String ERR_MSG_FMT_ROLES_CONFLICT =
+      "User [%s] has conflicting Conclave/Jaggaer roles (Conclave: %s, Jaggaer: %s)";
+  static final String ERR_MSG_FMT_CONCLAVE_USER_MISSING = "User [%s] not found in Conclave";
+  static final String ERR_MSG_FMT_JAGGAER_USER_MISSING = "User [%s] not found in Jaggaer";
+  static final String ERR_MSG_FMT_NO_ROLES = "User [%s] is neither buyer NOR supplier in Conclave";
+  static final String MSG_FMT_SYS_ROLES = "%s user [%s] has roles %s";
+  static final String MSG_FMT_BOTH_ROLES = "User [%s] is both buyer AND supplier in Conclave";
+
+  private final ConclaveService conclaveService;
+  private final ConclaveAPIConfig conclaveAPIConfig;
+  private final UserProfileService userProfileService;
+
+  public List<RolesEnum> getUserRoles(final String userId) {
+    Assert.hasLength(userId, "userId must not be empty");
+    var conclaveUser = conclaveService.getUserProfile(userId)
+        // CON-1680-AC2(a)
+        .orElseThrow(
+            () -> new ResourceNotFoundException(format(ERR_MSG_FMT_CONCLAVE_USER_MISSING, userId)));
+
+    var conclaveBuyerSupplierRoleKeys = Map.of(conclaveAPIConfig.getBuyerRoleKey(), RolesEnum.BUYER,
+        conclaveAPIConfig.getSupplierRoleKey(), RolesEnum.SUPPLIER);
+
+    var sysRoleMappings =
+        Map.of(SYSID_CONCLAVE, new HashSet<RolesEnum>(), SYSID_JAGGAER, new HashSet<RolesEnum>());
+
+    conclaveUser.getDetail().getRolePermissionInfo().stream().map(RolePermissionInfo::getRoleKey)
+        .filter(conclaveBuyerSupplierRoleKeys::containsKey).forEach(
+            rk -> sysRoleMappings.get(SYSID_CONCLAVE).add(conclaveBuyerSupplierRoleKeys.get(rk)));
+    log.debug(
+        format(MSG_FMT_SYS_ROLES, SYSID_CONCLAVE, userId, sysRoleMappings.get(SYSID_CONCLAVE)));
+    validateBuyerSupplierConclaveRoles(sysRoleMappings.get(SYSID_CONCLAVE), userId);
+
+    userProfileService.resolveBuyerUserByEmail(userId)
+        .ifPresent(su -> sysRoleMappings.get(SYSID_JAGGAER).add(RolesEnum.BUYER));
+    userProfileService.resolveSupplierData(userId)
+        .ifPresent(scd -> sysRoleMappings.get(SYSID_JAGGAER).add(RolesEnum.SUPPLIER));
+    log.debug(format(MSG_FMT_SYS_ROLES, SYSID_JAGGAER, userId, sysRoleMappings.get(SYSID_JAGGAER)));
+
+    if (sysRoleMappings.get(SYSID_JAGGAER).isEmpty()) {
+      // CON-1680-AC2(b)
+      throw new ResourceNotFoundException(format(ERR_MSG_FMT_JAGGAER_USER_MISSING, userId));
+    }
+
+    if (!Objects.equals(sysRoleMappings.get(SYSID_CONCLAVE), sysRoleMappings.get(SYSID_JAGGAER))) {
+      // CON-1680-AC5&6
+      throw new UserRolesConflictException(format(ERR_MSG_FMT_ROLES_CONFLICT, userId,
+          sysRoleMappings.get(SYSID_CONCLAVE), sysRoleMappings.get(SYSID_JAGGAER)));
+    }
+    return List.copyOf(sysRoleMappings.get(SYSID_CONCLAVE));
+  }
+
+  private void validateBuyerSupplierConclaveRoles(final Collection<RolesEnum> roleKeys,
+      final String userId) {
+    if (roleKeys == null || roleKeys.isEmpty()) {
+      // CON-1680-AC4
+      throw new UserRolesConflictException(format(ERR_MSG_FMT_NO_ROLES, userId));
+    }
+
+    if (roleKeys.size() >= 2) {
+      // CON-1680-AC7
+      log.warn(format(MSG_FMT_BOTH_ROLES, userId));
+    }
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/WebclientWrapper.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/WebclientWrapper.java
@@ -1,0 +1,43 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static java.util.Optional.ofNullable;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Function;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Experimental - {@link WebClient} generic helper functions. Primarily to avoid having to mock the
+ * webclient invocation chain in service class tests!
+ */
+@Service
+public class WebclientWrapper {
+
+  /**
+   * Uses the passed webclient, uri template and optional args to attempt retrieval of a remote
+   * resource, returning an {@link Optional} of the given resource or empty if a 404 not found is
+   * received.
+   *
+   * @param <T>
+   * @param type the class type
+   * @param webclient
+   * @param uriTemplate
+   * @param args
+   * @return optional of type or empty if not found
+   * @throws WebClientResponseException for all other errors
+   */
+  public <T> Optional<T> getOptionalResource(final Class<T> type, final WebClient webclient,
+      final String uriTemplate, final Object... args) {
+
+    Function<WebClientResponseException, Mono<T>> funcFallback404 =
+        ex -> ex.getRawStatusCode() == 404 ? Mono.empty() : Mono.error(ex);
+
+    return ofNullable(webclient.get().uri(uriTemplate, args).retrieve().bodyToMono(type)
+        .onErrorResume(WebClientResponseException.class, funcFallback404)
+        .block(Duration.ofSeconds(5)));
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,8 +77,11 @@ config:
         templateId: itt_445
       getBuyerCompanyProfile:
         # endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==GURU;SUBUSERLOGIN=={{PRINCIPAL}}
-        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=BRAVOID==${config.external.jaggaer.self-service-id}
-        principalPlaceholder: "{{PRINCIPAL}}"
+        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==BUYER;BRAVOID==${config.external.jaggaer.self-service-id}
+      getSupplierCompanyProfile:
+        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==SELLER;userEmail=={{PRINCIPAL}}        
+      getSupplierSubUserProfile:
+        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==SELLER;SUBUSERLOGIN=={{PRINCIPAL}}
       exportRfx:
         endpoint: /esop/jint/api/public/ja/v1/rfxs/{id}
 
@@ -99,6 +102,9 @@ config:
       # baseUrl: "SET IN ENV"
       # apiKey: "SET IN ENV"
       timeoutDuration: 5
+      # Role keys are incorrectly spelt in Conclave
+      buyerRoleKey: JAEGGER_BUYER
+      supplierRoleKey: JAEGGER_SUPPLIER      
       getUser:
         uriTemplate: /user-profiles?user-id={user-id}
       getUserContacts:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,8 @@ config:
         defaultTitleFormat: "%s-%s-%s"
         endpoint: /esop/jint/api/public/ja/v1/projects
         templateId: tender_49
+      getProject:
+        endpoint: /esop/jint/api/public/ja/v1/projects/{id}
       createRfx:
         # ProjectName-EventType e.g. RM1234-Lot1a-CCS-RFP
         defaultTitleFormat: "%s-%s"
@@ -75,7 +77,7 @@ config:
         templateId: itt_445
       getBuyerCompanyProfile:
         # endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==GURU;SUBUSERLOGIN=={{PRINCIPAL}}
-        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==BUYER;BRAVOID==${config.external.jaggaer.self-service-id}
+        endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=BRAVOID==${config.external.jaggaer.self-service-id}
         principalPlaceholder: "{{PRINCIPAL}}"
       exportRfx:
         endpoint: /esop/jint/api/public/ja/v1/rfxs/{id}
@@ -93,6 +95,14 @@ config:
       getEventTypesForAgreement:
         uriTemplate: /agreements/{agreement-id}/lots/{lot-id}/event-types
 
+    conclaveWrapper:
+      # baseUrl: "SET IN ENV"
+      # apiKey: "SET IN ENV"
+      timeoutDuration: 5
+      getUser:
+        uriTemplate: /user-profiles?user-id={user-id}
+      getUserContacts:
+        uriTemplate: /user-profiles/contacts?user-id={email}
 
 ---
 spring:

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +34,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.ContactPoint1;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.ProcurementProjectName;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.TeamMember;
 import uk.gov.crowncommercial.dts.scale.cat.service.ProcurementProjectService;
 import uk.gov.crowncommercial.dts.scale.cat.util.TestUtils;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
@@ -52,6 +55,7 @@ class ProjectsControllerTest {
   private static final String ORG = "CCS";
   private static final String PROJ_NAME = CA_NUMBER + '-' + LOT_NUMBER + '-' + ORG;
   private static final String EVENT_OCID = "ocds-abc123-1";
+  private static final String USER_NAME = "Jim Beam";
   private static final Integer PROC_PROJECT_ID = 1;
 
   private final AgreementDetails agreementDetails = new AgreementDetails();
@@ -209,4 +213,62 @@ class ProjectsControllerTest {
         .andExpect(content().string(expectedJson));
   }
 
+  @Test
+  void getProjectUsers_200_OK() throws Exception {
+
+    TeamMember teamMember = new TeamMember();
+    ContactPoint1 contact = new ContactPoint1();
+    contact.setEmail(PRINCIPAL);
+    contact.setName(USER_NAME);
+    teamMember.setId(PRINCIPAL);
+    teamMember.setContact(contact);
+
+    when(procurementProjectService.getProjectTeamMembers(PROC_PROJECT_ID))
+        .thenReturn(Arrays.asList(teamMember));
+
+    mockMvc
+        .perform(get("/tenders/projects/" + PROC_PROJECT_ID + "/users")
+            .with(validJwtReqPostProcessor).accept(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON)).andExpect(jsonPath("$.size()").value(1))
+        .andExpect(jsonPath("$[0].id", is(PRINCIPAL)))
+        .andExpect(jsonPath("$[0].contact.name", is(USER_NAME)))
+        .andExpect(jsonPath("$[0].contact.email", is(PRINCIPAL)));
+  }
+
+  @Test
+  void getProjectUsers_401_Forbidden_Invalid_JWT() throws Exception {
+    // No subject claim
+    var invalidJwtReqPostProcessor = jwt().authorities(new SimpleGrantedAuthority("CAT_USER"))
+        .jwt(jwt -> jwt.claims(claims -> claims.remove("sub")));
+
+    mockMvc
+        .perform(get("/tenders/projects/" + PROC_PROJECT_ID + "/users")
+            .with(invalidJwtReqPostProcessor).contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(agreementDetails)))
+        .andDo(print()).andExpect(status().isUnauthorized())
+        .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, startsWith("Bearer")))
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.errors", hasSize(1)))
+        .andExpect(jsonPath("$.errors[0].status", is("401 UNAUTHORIZED")))
+        .andExpect(jsonPath("$.errors[0].title", is("Missing, expired or invalid access token")));
+  }
+
+  @Test
+  void getProjectUsers_500_ISE() throws Exception {
+
+    when(procurementProjectService.getProjectTeamMembers(PROC_PROJECT_ID))
+        .thenThrow(new JaggaerApplicationException("1", "BANG"));
+
+    mockMvc
+        .perform(get("/tenders/projects/" + PROC_PROJECT_ID + "/users")
+            .with(validJwtReqPostProcessor).contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(agreementDetails)))
+        .andDo(print()).andExpect(status().isInternalServerError())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.errors", hasSize(1)))
+        .andExpect(jsonPath("$.errors[0].status", is("500 INTERNAL_SERVER_ERROR"))).andExpect(
+            jsonPath("$.errors[0].title", is("An error occurred invoking an upstream service")));
+  }
 }
+

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,14 +26,15 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
-import uk.gov.crowncommercial.dts.scale.cat.service.ProcurementProjectService;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.GetUserResponse.RolesEnum;
+import uk.gov.crowncommercial.dts.scale.cat.service.ProfileManagementService;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 
 /**
  * Web (mock MVC) Tenders controller tests. Security aware.
  */
 @WebMvcTest(TendersController.class)
-@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class, GlobalErrorHandler.class})
 @ActiveProfiles("test")
 class TendersControllerTest {
 
@@ -41,7 +44,7 @@ class TendersControllerTest {
   private MockMvc mockMvc;
 
   @MockBean
-  private ProcurementProjectService procurementProjectService;
+  private ProfileManagementService profileManagementService;
   private JwtRequestPostProcessor validJwtReqPostProcessor;
 
   @BeforeEach
@@ -60,6 +63,9 @@ class TendersControllerTest {
         .andExpect(jsonPath("$[*]", contains("EOI", "RFI", "CA", "DA", "FC", "TBD")));
   }
 
+  /*
+   * CON-1680-AC3
+   */
   @Test
   void listProcurementEventTypes_403_Forbidden() throws Exception {
     var invalidJwtReqPostProcessor =
@@ -83,6 +89,30 @@ class TendersControllerTest {
         .andExpect(jsonPath("$.errors", hasSize(1)))
         .andExpect(jsonPath("$.errors[0].status", is("401 UNAUTHORIZED")))
         .andExpect(jsonPath("$.errors[0].title", is("Missing, expired or invalid access token")));
+  }
+
+  @Test
+  void getUser_200_OK() throws Exception {
+    when(profileManagementService.getUserRoles(PRINCIPAL)).thenReturn(List.of(RolesEnum.BUYER));
+    mockMvc
+        .perform(get("/tenders/users/{user-id}", PRINCIPAL).with(validJwtReqPostProcessor)
+            .accept(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.roles.size()").value(1))
+        .andExpect(jsonPath("$.roles[0]", is("buyer")));
+  }
+
+  @Test
+  void getUser_403_Forbidden() throws Exception {
+    mockMvc
+        .perform(get("/tenders/users/{user-id}", "ted.crilly@craggyisland.com")
+            .with(validJwtReqPostProcessor).accept(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isForbidden())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.errors", hasSize(1)))
+        .andExpect(jsonPath("$.errors[0].status", is("403 FORBIDDEN"))).andExpect(jsonPath(
+            "$.errors[0].title", is("Authenticated user does not match requested user-id")));
   }
 
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ConclaveServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ConclaveServiceTest.java
@@ -1,9 +1,8 @@
 package uk.gov.crowncommercial.dts.scale.cat.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.reactive.function.client.WebClient;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.crowncommercial.dts.scale.cat.config.ConclaveAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserContactInfoList;
 import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserProfileResponseInfo;
@@ -23,7 +21,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.Use
 @SpringBootTest(classes = {ConclaveService.class, ConclaveAPIConfig.class},
     webEnvironment = WebEnvironment.NONE)
 @EnableConfigurationProperties(ConclaveAPIConfig.class)
-class ConclaveUserServiceTest {
+class ConclaveServiceTest {
 
   private static final String CONCLAVE_USER_ID = "12345";
 
@@ -32,6 +30,9 @@ class ConclaveUserServiceTest {
 
   @MockBean
   private UserProfileResponseInfo userProfileResponseInfo;
+
+  @MockBean
+  private WebclientWrapper webclientWrapper;
 
   @MockBean
   private UserContactInfoList userContactInfoList;
@@ -43,31 +44,27 @@ class ConclaveUserServiceTest {
   private ConclaveService conclaveService;
 
   @Test
-  void testGetUserProfile() throws JsonProcessingException {
+  void testGetUserProfile() {
 
     // Mock behaviours
-    when(conclaveWebClient.get()
-        .uri(conclaveAPIConfig.getGetUser().get("uriTemplate"), CONCLAVE_USER_ID).retrieve()
-        .bodyToMono(eq(UserProfileResponseInfo.class))
-        .block(Duration.ofSeconds(conclaveAPIConfig.getTimeoutDuration())))
-            .thenReturn(userProfileResponseInfo);
+    when(webclientWrapper.getOptionalResource(UserProfileResponseInfo.class, conclaveWebClient,
+        conclaveAPIConfig.getGetUser().get("uriTemplate"), CONCLAVE_USER_ID))
+            .thenReturn(Optional.of(userProfileResponseInfo));
 
     // Invoke
     var userProfile = conclaveService.getUserProfile(CONCLAVE_USER_ID);
 
     // Verify
-    assertEquals(userProfileResponseInfo, userProfile);
+    assertEquals(Optional.of(userProfileResponseInfo), userProfile);
   }
 
   @Test
-  void testGetUserContacts() throws JsonProcessingException {
+  void testGetUserContacts() {
 
     // Mock behaviours
-    when(conclaveWebClient.get()
-        .uri(conclaveAPIConfig.getGetUserContacts().get("uriTemplate"), CONCLAVE_USER_ID).retrieve()
-        .bodyToMono(eq(UserContactInfoList.class))
-        .block(Duration.ofSeconds(conclaveAPIConfig.getTimeoutDuration())))
-            .thenReturn(userContactInfoList);
+    when(webclientWrapper.getOptionalResource(UserContactInfoList.class, conclaveWebClient,
+        conclaveAPIConfig.getGetUserContacts().get("uriTemplate"), CONCLAVE_USER_ID))
+            .thenReturn(Optional.of(userContactInfoList));
 
     // Invoke
     var userContacts = conclaveService.getUserContacts(CONCLAVE_USER_ID);

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ConclaveUserServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ConclaveUserServiceTest.java
@@ -1,0 +1,79 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.reactive.function.client.WebClient;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import uk.gov.crowncommercial.dts.scale.cat.config.ConclaveAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserContactInfoList;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserProfileResponseInfo;
+
+/**
+ * Service layer tests
+ */
+@SpringBootTest(classes = {ConclaveService.class, ConclaveAPIConfig.class},
+    webEnvironment = WebEnvironment.NONE)
+@EnableConfigurationProperties(ConclaveAPIConfig.class)
+class ConclaveUserServiceTest {
+
+  private static final String CONCLAVE_USER_ID = "12345";
+
+  @MockBean(answer = Answers.RETURNS_DEEP_STUBS)
+  private WebClient conclaveWebClient;
+
+  @MockBean
+  private UserProfileResponseInfo userProfileResponseInfo;
+
+  @MockBean
+  private UserContactInfoList userContactInfoList;
+
+  @Autowired
+  private ConclaveAPIConfig conclaveAPIConfig;
+
+  @Autowired
+  private ConclaveService conclaveService;
+
+  @Test
+  void testGetUserProfile() throws JsonProcessingException {
+
+    // Mock behaviours
+    when(conclaveWebClient.get()
+        .uri(conclaveAPIConfig.getGetUser().get("uriTemplate"), CONCLAVE_USER_ID).retrieve()
+        .bodyToMono(eq(UserProfileResponseInfo.class))
+        .block(Duration.ofSeconds(conclaveAPIConfig.getTimeoutDuration())))
+            .thenReturn(userProfileResponseInfo);
+
+    // Invoke
+    var userProfile = conclaveService.getUserProfile(CONCLAVE_USER_ID);
+
+    // Verify
+    assertEquals(userProfileResponseInfo, userProfile);
+  }
+
+  @Test
+  void testGetUserContacts() throws JsonProcessingException {
+
+    // Mock behaviours
+    when(conclaveWebClient.get()
+        .uri(conclaveAPIConfig.getGetUserContacts().get("uriTemplate"), CONCLAVE_USER_ID).retrieve()
+        .bodyToMono(eq(UserContactInfoList.class))
+        .block(Duration.ofSeconds(conclaveAPIConfig.getTimeoutDuration())))
+            .thenReturn(userContactInfoList);
+
+    // Invoke
+    var userContacts = conclaveService.getUserContacts(CONCLAVE_USER_ID);
+
+    // Verify
+    assertEquals(userContactInfoList, userContacts);
+  }
+
+}

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementProject;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.*;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.ReturnSubUser.SubUser;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementEventRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementProjectRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
@@ -58,8 +59,13 @@ class ProcurementEventServiceTest {
   private static final String OCID_PREFIX = "b5fd17";
   private static final String UPDATED_EVENT_NAME = "New Name";
   private static final String UPDATED_EVENT_TYPE = "DA";
+  private static final String BUYER_COMPANY_BRAVO_ID = "54321";
   private static final DefineEventType EVENT_TYPE = DefineEventType.DA;
   private static final Boolean DOWNSELECTED_SUPPLIERS = true;
+  private static final Optional<SubUser> JAGGAER_USER =
+      Optional.of(SubUser.builder().userId(JAGGAER_USER_ID).email(PRINCIPAL).build());
+  private static final ReturnCompanyInfo BUYER_COMPANY_INFO =
+      ReturnCompanyInfo.builder().bravoId(BUYER_COMPANY_BRAVO_ID).build();
 
   @MockBean(answer = Answers.RETURNS_DEEP_STUBS)
   private WebClient jaggaerWebClient;
@@ -99,7 +105,8 @@ class ProcurementEventServiceTest {
     var procurementEvent = ProcurementEvent.builder().build();
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
+    when(userProfileService.resolveBuyerCompanyByEmail(PRINCIPAL)).thenReturn(BUYER_COMPANY_INFO);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateRfx().get("endpoint"))
         .bodyValue(any(CreateUpdateRfx.class)).retrieve()
         .bodyToMono(eq(CreateUpdateRfxResponse.class))
@@ -173,7 +180,8 @@ class ProcurementEventServiceTest {
     var procurementEvent = ProcurementEvent.builder().build();
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
+    when(userProfileService.resolveBuyerCompanyByEmail(PRINCIPAL)).thenReturn(BUYER_COMPANY_INFO);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateRfx().get("endpoint"))
         .bodyValue(any(CreateUpdateRfx.class)).retrieve()
         .bodyToMono(eq(CreateUpdateRfxResponse.class))
@@ -240,7 +248,7 @@ class ProcurementEventServiceTest {
     createUpdateRfxResponse.setReturnCode(0);
     createUpdateRfxResponse.setReturnMessage("OK");
 
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateRfx().get("endpoint"))
         .bodyValue(argThat(new UpdateEventNameMatcher(updateRfx))).retrieve()
         .bodyToMono(eq(CreateUpdateRfxResponse.class))
@@ -272,7 +280,7 @@ class ProcurementEventServiceTest {
     createUpdateRfxResponse.setReturnCode(0);
     createUpdateRfxResponse.setReturnMessage("OK");
 
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateRfx().get("endpoint"))
         .bodyValue(argThat(new UpdateEventNameMatcher(updateRfx))).retrieve()
         .bodyToMono(eq(CreateUpdateRfxResponse.class))
@@ -309,7 +317,7 @@ class ProcurementEventServiceTest {
     var updateEvent = new UpdateEvent();
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
 
     // Invoke & assert
     var ex = assertThrows(IllegalArgumentException.class, () -> procurementEventService
@@ -323,7 +331,7 @@ class ProcurementEventServiceTest {
     var updateEvent = new UpdateEvent();
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
 
     // Invoke & assert
     var ex = assertThrows(ResourceNotFoundException.class, () -> procurementEventService
@@ -344,7 +352,7 @@ class ProcurementEventServiceTest {
     var procurementEvent = ProcurementEvent.builder().build();
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateRfx().get("endpoint"))
         .bodyValue(any(CreateUpdateRfx.class)).retrieve()
         .bodyToMono(eq(CreateUpdateRfxResponse.class))

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
@@ -33,11 +33,8 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.CreateEvent;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.EventSummary;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.EventType;
-import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.CreateUpdateProject;
-import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.CreateUpdateProjectResponse;
-import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.OperationCode;
-import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Project;
-import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Tender;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.*;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.ReturnSubUser.SubUser;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementEventRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementProjectRepo;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
@@ -64,7 +61,12 @@ class ProcurementProjectServiceTest {
   private static final String EVENT_OCID = "ocds-abc123-1";
   private static final Integer PROC_PROJECT_ID = 1;
   private static final String UPDATED_PROJECT_NAME = "New name";
+  private static final String BUYER_COMPANY_BRAVO_ID = "54321";
   private static final CreateEvent CREATE_EVENT = new CreateEvent();
+  private static final Optional<SubUser> JAGGAER_USER =
+      Optional.of(SubUser.builder().userId(JAGGAER_USER_ID).email(PRINCIPAL).build());
+  private static final ReturnCompanyInfo BUYER_COMPANY_INFO =
+      ReturnCompanyInfo.builder().bravoId(BUYER_COMPANY_BRAVO_ID).build();
 
   private final AgreementDetails agreementDetails = new AgreementDetails();
 
@@ -119,7 +121,8 @@ class ProcurementProjectServiceTest {
     eventSummary.setId(EVENT_OCID);
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
+    when(userProfileService.resolveBuyerCompanyByEmail(PRINCIPAL)).thenReturn(BUYER_COMPANY_INFO);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateProject().get("endpoint"))
         .bodyValue(any(CreateUpdateProject.class)).retrieve()
         .bodyToMono(eq(CreateUpdateProjectResponse.class))
@@ -144,7 +147,7 @@ class ProcurementProjectServiceTest {
     assertEquals(ORG, draftProcurementProject.getDefaultName().getComponents().getOrg());
 
     // Verify
-    verify(userProfileService).resolveJaggaerUserId(PRINCIPAL);
+    verify(userProfileService).resolveBuyerUserByEmail(PRINCIPAL);
     verify(procurementProjectRepo).save(any(ProcurementProject.class));
     verify(procurementEventService).createEvent(PROC_PROJECT_ID, CREATE_EVENT, null, PRINCIPAL);
   }
@@ -157,7 +160,8 @@ class ProcurementProjectServiceTest {
     jaggaerErrorResponse.setReturnMessage("NOT OK");
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
+    when(userProfileService.resolveBuyerCompanyByEmail(PRINCIPAL)).thenReturn(BUYER_COMPANY_INFO);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateProject().get("endpoint"))
         .bodyValue(any(CreateUpdateProject.class)).retrieve()
         .bodyToMono(eq(CreateUpdateProjectResponse.class))
@@ -185,7 +189,7 @@ class ProcurementProjectServiceTest {
         new CreateUpdateProject(OperationCode.UPDATE, Project.builder().tender(tender).build());
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
     when(jaggaerWebClient.post().uri(jaggaerAPIConfig.getCreateProject().get("endpoint"))
         .bodyValue(argThat(new UpdateProjectMatcher(createUpdateProject))).retrieve()
         .bodyToMono(eq(CreateUpdateProjectResponse.class))
@@ -214,7 +218,7 @@ class ProcurementProjectServiceTest {
   void testUpdateProcurementProjectNameThrowsIllegalArgumentException() throws Exception {
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
 
     // Invoke & assert
     var ex = assertThrows(IllegalArgumentException.class, () -> procurementProjectService
@@ -226,7 +230,7 @@ class ProcurementProjectServiceTest {
   void testUpdateProcurementEventNameThrowsResourceNotFoundApplicationException() throws Exception {
 
     // Mock behaviours
-    when(userProfileService.resolveJaggaerUserId(PRINCIPAL)).thenReturn(JAGGAER_USER_ID);
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
 
     // Invoke & assert
     var ex = assertThrows(ResourceNotFoundException.class, () -> procurementProjectService

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
@@ -75,6 +75,9 @@ class ProcurementProjectServiceTest {
   private UserProfileService userProfileService;
 
   @MockBean
+  private ConclaveService conclaveService;
+
+  @MockBean
   private ProcurementProjectRepo procurementProjectRepo;
 
   @MockBean

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementServiceTest.java
@@ -1,0 +1,212 @@
+package uk.gov.crowncommercial.dts.scale.cat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.crowncommercial.dts.scale.cat.config.ConclaveAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
+import uk.gov.crowncommercial.dts.scale.cat.exception.UserRolesConflictException;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.RolePermissionInfo;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserProfileResponseInfo;
+import uk.gov.crowncommercial.dts.scale.cat.model.conclave_wrapper.generated.UserResponseDetail;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.GetUserResponse.RolesEnum;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.ReturnCompanyData;
+import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.ReturnSubUser.SubUser;
+
+/**
+ *
+ */
+@SpringBootTest(classes = {ProfileManagementService.class, ConclaveAPIConfig.class},
+    webEnvironment = WebEnvironment.NONE)
+@EnableConfigurationProperties(ConclaveAPIConfig.class)
+class ProfileManagementServiceTest {
+
+  private static final String USERID = "john.smith@example.com";
+  private static final String ROLEKEY_BUYER = "JAEGGER_BUYER";
+  private static final String ROLEKEY_SUPPLIER = "JAEGGER_SUPPLIER";
+
+  @MockBean
+  private ConclaveService conclaveService;
+
+  @MockBean
+  private UserProfileService userProfileService;
+
+  @Autowired
+  private ProfileManagementService profileManagementService;
+
+  /*
+   * CON-1680-AC1(a)
+   */
+  @Test
+  void testGetUserRolesConclaveBuyerJaggaerBuyer() {
+
+    var rolePermissionInfo = new RolePermissionInfo().roleKey(ROLEKEY_BUYER);
+    var userProfileResponseInfo = new UserProfileResponseInfo().userName(USERID)
+        .detail(new UserResponseDetail().rolePermissionInfo(List.of(rolePermissionInfo)));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+    when(userProfileService.resolveBuyerUserByEmail(USERID))
+        .thenReturn(Optional.of(SubUser.builder().build()));
+
+    var userRoles = profileManagementService.getUserRoles(USERID);
+
+    assertEquals(1, userRoles.size());
+    assertEquals(RolesEnum.BUYER, userRoles.get(0));
+  }
+
+  /*
+   * CON-1680-AC1(b)
+   */
+  @Test
+  void testGetUserRolesConclaveSupplierJaggaerSupplier() {
+
+    var rolePermissionInfo = new RolePermissionInfo().roleKey(ROLEKEY_SUPPLIER);
+    var userProfileResponseInfo = new UserProfileResponseInfo().userName(USERID)
+        .detail(new UserResponseDetail().rolePermissionInfo(List.of(rolePermissionInfo)));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+    when(userProfileService.resolveSupplierData(USERID))
+        .thenReturn(Optional.of(new ReturnCompanyData()));
+
+    var userRoles = profileManagementService.getUserRoles(USERID);
+
+    assertEquals(1, userRoles.size());
+    assertEquals(RolesEnum.SUPPLIER, userRoles.get(0));
+  }
+
+  /*
+   * CON-1680-AC2(a)
+   */
+  @Test
+  void testGetUserRolesNoConclaveUserThrowsResourceNotFound() {
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.empty());
+
+    var ex = assertThrows(ResourceNotFoundException.class,
+        () -> profileManagementService.getUserRoles(USERID));
+
+    assertEquals("User [" + USERID + "] not found in Conclave", ex.getMessage());
+  }
+
+  /*
+   * CON-1680-AC2(b)
+   */
+  @Test
+  void testGetUserRolesNoJaggaerUserThrowsResourceNotFound() {
+
+    var rolePermissionInfo = new RolePermissionInfo().roleKey(ROLEKEY_BUYER);
+    var userProfileResponseInfo = new UserProfileResponseInfo().userName(USERID)
+        .detail(new UserResponseDetail().rolePermissionInfo(List.of(rolePermissionInfo)));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+    when(userProfileService.resolveBuyerUserByEmail(USERID)).thenReturn(Optional.empty());
+    when(userProfileService.resolveSupplierData(USERID)).thenReturn(Optional.empty());
+
+    var ex = assertThrows(ResourceNotFoundException.class,
+        () -> profileManagementService.getUserRoles(USERID));
+
+    assertEquals("User [" + USERID + "] not found in Jaggaer", ex.getMessage());
+  }
+
+  /*
+   * CON-1680-AC4
+   */
+  @Test
+  void testGetUserRolesNoBuyerSupplierRoleThrowsUserRolesConflictException() {
+
+    var userProfileResponseInfo = new UserProfileResponseInfo().userName(USERID)
+        .detail(new UserResponseDetail().rolePermissionInfo(new ArrayList<>()));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+
+    var ex = assertThrows(UserRolesConflictException.class,
+        () -> profileManagementService.getUserRoles(USERID));
+
+    assertEquals("User [" + USERID + "] is neither buyer NOR supplier in Conclave",
+        ex.getMessage());
+  }
+
+  /*
+   * CON-1680-AC5
+   */
+  @Test
+  void testGetUserRolesConclaveSupplierJaggaerBuyer() {
+
+    var rolePermissionInfoSupplier = new RolePermissionInfo().roleKey(ROLEKEY_SUPPLIER);
+    var userProfileResponseInfo = new UserProfileResponseInfo().userName(USERID)
+        .detail(new UserResponseDetail().rolePermissionInfo(List.of(rolePermissionInfoSupplier)));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+    when(userProfileService.resolveBuyerUserByEmail(USERID))
+        .thenReturn(Optional.of(SubUser.builder().build()));
+    when(userProfileService.resolveSupplierData(USERID)).thenReturn(Optional.empty());
+
+    var ex = assertThrows(UserRolesConflictException.class,
+        () -> profileManagementService.getUserRoles(USERID));
+
+    assertEquals(
+        "User [" + USERID
+            + "] has conflicting Conclave/Jaggaer roles (Conclave: [supplier], Jaggaer: [buyer])",
+        ex.getMessage());
+  }
+
+  /*
+   * CON-1680-AC6
+   */
+  @Test
+  void testGetUserRolesConclaveBuyerJaggaerSupplier() {
+
+    var rolePermissionInfoSupplier = new RolePermissionInfo().roleKey(ROLEKEY_BUYER);
+    var userProfileResponseInfo = new UserProfileResponseInfo().userName(USERID)
+        .detail(new UserResponseDetail().rolePermissionInfo(List.of(rolePermissionInfoSupplier)));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+    when(userProfileService.resolveBuyerUserByEmail(USERID)).thenReturn(Optional.empty());
+    when(userProfileService.resolveSupplierData(USERID))
+        .thenReturn(Optional.of(new ReturnCompanyData()));
+
+    var ex = assertThrows(UserRolesConflictException.class,
+        () -> profileManagementService.getUserRoles(USERID));
+
+    assertEquals(
+        "User [" + USERID
+            + "] has conflicting Conclave/Jaggaer roles (Conclave: [buyer], Jaggaer: [supplier])",
+        ex.getMessage());
+  }
+
+  /*
+   * CON-1680-AC17
+   */
+  @Test
+  void testGetUserRolesConclaveBothJaggaerBoth() {
+
+    var rolePermissionInfoBuyer = new RolePermissionInfo().roleKey(ROLEKEY_BUYER);
+    var rolePermissionInfoSupplier = new RolePermissionInfo().roleKey(ROLEKEY_SUPPLIER);
+    var userProfileResponseInfo =
+        new UserProfileResponseInfo().userName(USERID).detail(new UserResponseDetail()
+            .rolePermissionInfo(List.of(rolePermissionInfoBuyer, rolePermissionInfoSupplier)));
+
+    when(conclaveService.getUserProfile(USERID)).thenReturn(Optional.of(userProfileResponseInfo));
+    when(userProfileService.resolveBuyerUserByEmail(USERID))
+        .thenReturn(Optional.of(SubUser.builder().build()));
+    when(userProfileService.resolveSupplierData(USERID))
+        .thenReturn(Optional.of(new ReturnCompanyData()));
+
+    var userRoles = profileManagementService.getUserRoles(USERID);
+
+    assertEquals(2, userRoles.size());
+    assertTrue(userRoles.stream().anyMatch(re -> RolesEnum.BUYER == re));
+    assertTrue(userRoles.stream().anyMatch(re -> RolesEnum.SUPPLIER == re));
+  }
+
+}

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TestUtils.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TestUtils.java
@@ -2,10 +2,11 @@ package uk.gov.crowncommercial.dts.scale.cat.util;
 
 import java.util.Arrays;
 import java.util.List;
-
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.ProjectEventType;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.ContactPoint1;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.DefineEventType;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.EventType;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.TeamMember;
 
 public class TestUtils {
 
@@ -14,6 +15,9 @@ public class TestUtils {
   public static final String CAPABILITY_ASSESSMENT = "Capability Assessment";
   public static final String DIRECT_AWARD = "Direct Award";
   public static final String FURTHER_COMPETITION = "Further Competition";
+
+  public static final String USER_NAME = "Jim Beam";
+  public static final String USERID = "jbeam@ccs.org.uk";
 
   public static EventType getEventType(final DefineEventType defineEventType,
       final String description, final boolean preMarketActivity) {
@@ -49,5 +53,15 @@ public class TestUtils {
         getProjectEventType("CA", CAPABILITY_ASSESSMENT, true),
         getProjectEventType("DA", DIRECT_AWARD, false),
         getProjectEventType("FC", FURTHER_COMPETITION, false)};
+  }
+
+  public static TeamMember getTeamMember() {
+    TeamMember teamMember = new TeamMember();
+    ContactPoint1 contact = new ContactPoint1();
+    contact.setEmail(USERID);
+    contact.setName(USER_NAME);
+    teamMember.setId(USERID);
+    teamMember.setContact(contact);
+    return teamMember;
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://crowncommercialservice.atlassian.net/browse/CON-1729

### Change description ###
To permit external connections to the Tenders API, move it to the public domain with nginx IP auth in front of it.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
