### PR TITLE
Added a 'devMode' application flag - to assist in development

### DIFF
--- a/iac/environments/dev/main.tf
+++ b/iac/environments/dev/main.tf
@@ -9,4 +9,5 @@ module "deploy-all" {
   environment = "dev"
   cf_username = var.cf_username
   cf_password = var.cf_password
+  dev_mode    = true
 }

--- a/iac/environments/sbx1/main.tf
+++ b/iac/environments/sbx1/main.tf
@@ -10,4 +10,5 @@ module "deploy-all" {
   cf_username = var.cf_username
   cf_password = var.cf_password
   instances   = 1
+  dev_mode    = true
 }

--- a/iac/environments/sbx2/main.tf
+++ b/iac/environments/sbx2/main.tf
@@ -10,4 +10,5 @@ module "deploy-all" {
   cf_username = var.cf_username
   cf_password = var.cf_password
   instances   = 1
+  dev_mode    = true
 }

--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -79,6 +79,7 @@ resource "cloudfoundry_app" "cat_service" {
     "config.external.agreements-service.baseUrl" : data.aws_ssm_parameter.agreements_service_base_url.value
     "config.external.conclave-wrapper.baseUrl" : data.aws_ssm_parameter.conclave_wrapper_api_base_url.value
     "config.external.conclave-wrapper.apiKey" : data.aws_ssm_parameter.conclave_wrapper_api_key.value
+    "config.flags.devMode" : var.dev_mode
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"

--- a/iac/modules/cat-service/variables.tf
+++ b/iac/modules/cat-service/variables.tf
@@ -32,3 +32,4 @@ variable "cf_password" {
   sensitive = true
 }
 
+variable "dev_mode" {}

--- a/iac/modules/configs/deploy-all/main.tf
+++ b/iac/modules/configs/deploy-all/main.tf
@@ -13,4 +13,5 @@ module "cat-service" {
   cf_password  = var.cf_password
   instances    = var.instances
   memory       = var.memory
+  dev_mode     = var.dev_mode
 }

--- a/iac/modules/configs/deploy-all/variables.tf
+++ b/iac/modules/configs/deploy-all/variables.tf
@@ -21,3 +21,7 @@ variable "instances" {
 variable "memory" {
   default = 1024
 }
+
+variable "dev_mode" {
+  default = false
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApplicationFlagsConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApplicationFlagsConfig.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import lombok.Data;
+
+/**
+ *
+ */
+@Configuration
+@ConfigurationProperties(prefix = "config.flags", ignoreUnknownFields = true)
+@Data
+public class ApplicationFlagsConfig {
+
+  private Boolean devMode;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/Constants.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/Constants.java
@@ -15,4 +15,8 @@ public class Constants {
   public static final String JWT_CLAIM_SUBJECT = "sub";
   public static final String ERR_MSG_UNAUTHORISED = "Missing, expired or invalid access token";
   public static final String ERR_MSG_FORBIDDEN = "Access to the requested resource is forbidden";
+  public static final String ERR_MSG_DEFAULT = "An error occurred processing the request";
+  public static final String ERR_MSG_UPSTREAM = "An error occurred invoking an upstream service";
+  public static final String ERR_MSG_VALIDATION = "Validation error processing the request";
+  public static final String ERR_MSG_RESOURCE_NOT_FOUND = "Resource not found";
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
@@ -1,8 +1,10 @@
 package uk.gov.crowncommercial.dts.scale.cat.utils;
 
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.model.ApiError;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
@@ -17,6 +19,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.RfxSetting;
 public class TendersAPIModelUtils {
 
   private final JaggaerAPIConfig jaggaerAPIConfig;
+  private final ApplicationFlagsConfig appFlagsConfig;
 
   public DraftProcurementProject buildDraftProcurementProject(
       final AgreementDetails agreementDetails, final Integer procurementID, final String eventID,
@@ -49,6 +52,12 @@ public class TendersAPIModelUtils {
     eventSummary.setEventType(type);
     eventSummary.setEventSupportId(supportID);
     return eventSummary;
+  }
+
+  public Errors buildDefaultErrors(final String status, final String title, final String details) {
+    var apiError = new ApiError(status, title,
+        (appFlagsConfig.getDevMode() != null && appFlagsConfig.getDevMode()) ? details : "");
+    return buildErrors(Arrays.asList(apiError));
   }
 
   public Errors buildErrors(final List<ApiError> apiErrors) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,7 +109,8 @@ config:
         uriTemplate: /user-profiles?user-id={user-id}
       getUserContacts:
         uriTemplate: /user-profiles/contacts?user-id={email}
-
+  #flags:
+    # devMode: "SET IN ENV"
 ---
 spring:
   config:

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
@@ -44,7 +45,7 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
  * Controller tests
  */
 @WebMvcTest(EventsController.class)
-@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class, ApplicationFlagsConfig.class})
 @ActiveProfiles("test")
 class EventsControllerTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.AgreementDetails;
@@ -45,7 +46,7 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
  * Web (mock MVC) Project controller tests. Security aware.
  */
 @WebMvcTest(ProjectsController.class)
-@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class, ApplicationFlagsConfig.class})
 @ActiveProfiles("test")
 class ProjectsControllerTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.GetUserResponse.RolesEnum;
 import uk.gov.crowncommercial.dts.scale.cat.service.ProfileManagementService;
@@ -34,7 +35,8 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
  * Web (mock MVC) Tenders controller tests. Security aware.
  */
 @WebMvcTest(TendersController.class)
-@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class, GlobalErrorHandler.class})
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class, GlobalErrorHandler.class,
+    ApplicationFlagsConfig.class})
 @ActiveProfiles("test")
 class TendersControllerTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.reactive.function.client.WebClient;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.OcdsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
@@ -38,10 +39,9 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 /**
  * Service layer tests
  */
-@SpringBootTest(
-    classes = {ProcurementEventService.class, JaggaerAPIConfig.class, OcdsConfig.class,
-        TendersAPIModelUtils.class, RetryableTendersDBDelegate.class, ValidationService.class},
-    webEnvironment = WebEnvironment.NONE)
+@SpringBootTest(classes = {ProcurementEventService.class, JaggaerAPIConfig.class, OcdsConfig.class,
+    TendersAPIModelUtils.class, RetryableTendersDBDelegate.class, ValidationService.class,
+    ApplicationFlagsConfig.class}, webEnvironment = WebEnvironment.NONE)
 @EnableConfigurationProperties(JaggaerAPIConfig.class)
 class ProcurementEventServiceTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.reactive.function.client.WebClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.crowncommercial.dts.scale.cat.config.AgreementsServiceAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
@@ -44,10 +45,9 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 /**
  * Service layer tests
  */
-@SpringBootTest(
-    classes = {ProcurementProjectService.class, JaggaerAPIConfig.class, TendersAPIModelUtils.class,
-        RetryableTendersDBDelegate.class, ModelMapper.class, JaggaerService.class},
-    webEnvironment = WebEnvironment.NONE)
+@SpringBootTest(classes = {ProcurementProjectService.class, JaggaerAPIConfig.class,
+    TendersAPIModelUtils.class, RetryableTendersDBDelegate.class, ModelMapper.class,
+    JaggaerService.class, ApplicationFlagsConfig.class}, webEnvironment = WebEnvironment.NONE)
 @EnableConfigurationProperties(JaggaerAPIConfig.class)
 class ProcurementProjectServiceTest {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TendersAPIModelUtilsTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TendersAPIModelUtilsTest.java
@@ -1,0 +1,67 @@
+package uk.gov.crowncommercial.dts.scale.cat.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
+import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.Errors;
+import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
+
+@SpringBootTest(classes = {TendersAPIModelUtils.class, JaggaerAPIConfig.class},
+    webEnvironment = WebEnvironment.NONE)
+class TendersAPIModelUtilsTest {
+
+  private static final String ERROR_STATUS = "error status";
+  private static final String ERROR_TITLE = "error title";
+  private static final String ERROR_MESSAGE = "error message";
+
+  @MockBean
+  ApplicationFlagsConfig appFlagsConfig;
+
+  @Autowired
+  TendersAPIModelUtils utils;
+
+  @Test
+  void testBuildDefaultErrors_devMode_true() throws Exception {
+
+    when(appFlagsConfig.getDevMode()).thenReturn(true);
+
+    Errors errors = utils.buildDefaultErrors(ERROR_STATUS, ERROR_TITLE, ERROR_MESSAGE);
+
+    assertEquals(1, errors.getErrors().size());
+    assertEquals(ERROR_STATUS, errors.getErrors().get(0).getStatus());
+    assertEquals(ERROR_TITLE, errors.getErrors().get(0).getTitle());
+    assertEquals(ERROR_MESSAGE, errors.getErrors().get(0).getDetail());
+  }
+
+  @Test
+  void testBuildDefaultErrors_devMode_false() throws Exception {
+
+    when(appFlagsConfig.getDevMode()).thenReturn(false);
+
+    Errors errors = utils.buildDefaultErrors(ERROR_STATUS, ERROR_TITLE, ERROR_MESSAGE);
+
+    assertEquals(1, errors.getErrors().size());
+    assertEquals(ERROR_STATUS, errors.getErrors().get(0).getStatus());
+    assertEquals(ERROR_TITLE, errors.getErrors().get(0).getTitle());
+    assertEquals("", errors.getErrors().get(0).getDetail());
+  }
+
+  @Test
+  void testBuildDefaultErrors_devMode_null() throws Exception {
+
+    when(appFlagsConfig.getDevMode()).thenReturn(null);
+
+    Errors errors = utils.buildDefaultErrors(ERROR_STATUS, ERROR_TITLE, ERROR_MESSAGE);
+
+    assertEquals(1, errors.getErrors().size());
+    assertEquals(ERROR_STATUS, errors.getErrors().get(0).getStatus());
+    assertEquals(ERROR_TITLE, errors.getErrors().get(0).getTitle());
+    assertEquals("", errors.getErrors().get(0).getDetail());
+  }
+}


### PR DESCRIPTION
When set to 'true' error details API responses will include the
exception message. Only enabled on dev and sandboxes.

### JIRA link (if applicable) ###

Added a `devMode` flag that when set to true will return the root exception details in the error response via the API. In most cases this is currently set to return an empty string, as we don't want to expose any details in errors (and nothing more sophisticated is defined/implemented yet).

As UI devs are encountering 500/other errors when getting the pieces talking to each other - thought this might be useful to give a bit more of an immediate hint as to what the issue may be - be less frustrating for the UI devs if they have a clue what the problem may be, and less need for them to ask questions of back end devs.

Tom had the great suggestion of making configurable - so added an ApplicationFlagsConfig class - to contain this, and potentially more flags in future.

This will default to 'false' unless overridden.

A couple of the Global Error Handlers didn't follow this pattern - and had existing tests - so I have left them functioning as they were (may be that we want to change them too - but thought not for now - but happy to change)

### Change description ###



### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
