### PR TITLE
SCAT-2153 - fixes to 'pocurementID` typo to align with API fix

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
@@ -22,7 +22,7 @@ public class TendersAPIModelUtils {
       final AgreementDetails agreementDetails, final Integer procurementID, final String eventID,
       final String projectTitle) {
     var draftProcurementProject = new DraftProcurementProject();
-    draftProcurementProject.setPocurementID(procurementID);
+    draftProcurementProject.setProcurementID(procurementID);
     draftProcurementProject.setEventId(eventID);
 
     var defaultNameComponents = new DefaultNameComponents();

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsControllerTest.java
@@ -95,7 +95,7 @@ class ProjectsControllerTest {
             .content(objectMapper.writeValueAsString(agreementDetails)))
         .andDo(print()).andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
-        .andExpect(jsonPath("$.pocurementID").value(PROC_PROJECT_ID))
+        .andExpect(jsonPath("$.procurementID").value(PROC_PROJECT_ID))
         .andExpect(jsonPath("$.eventId").value(EVENT_OCID))
         .andExpect(jsonPath("$.defaultName.name").value(PROJ_NAME))
         .andExpect(jsonPath("$.defaultName.components.agreementId").value(CA_NUMBER))

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectServiceTest.java
@@ -138,7 +138,7 @@ class ProcurementProjectServiceTest {
         procurementProjectService.createFromAgreementDetails(agreementDetails, PRINCIPAL);
 
     // Assert
-    assertEquals(PROC_PROJECT_ID, draftProcurementProject.getPocurementID());
+    assertEquals(PROC_PROJECT_ID, draftProcurementProject.getProcurementID());
     assertEquals(EVENT_OCID, draftProcurementProject.getEventId());
     assertEquals(CA_NUMBER + '-' + LOT_NUMBER + '-' + ORG,
         draftProcurementProject.getDefaultName().getName());


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-2153

### Change description ###



### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
