### PR TITLE
SCAT-2394 - cannot update an eventType which is not TBD

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -207,8 +207,15 @@ public class ProcurementEventService {
 
     // Update event type
     if (updateEvent.getEventType() != null) {
-      event.setEventType(updateEvent.getEventType().getValue());
-      updateDB = true;
+      var existingEventType = event.getEventType();
+      if (existingEventType == null || existingEventType.isBlank()
+          || event.getEventType().equals("TBD")) {
+        event.setEventType(updateEvent.getEventType().getValue());
+        updateDB = true;
+      } else {
+        throw new IllegalArgumentException(
+            "Cannot update an existing event type of '" + event.getEventType() + "'");
+      }
     }
 
     // Save to Jaggaer

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -384,4 +384,27 @@ class ProcurementEventServiceTest {
     assertEquals("Jaggaer application exception, Code: [1], Message: [NOT OK]", jagEx.getMessage());
   }
 
+  @Test
+  void testUpdateProcurementEventTypeThrowsIllegalArgumentException() throws Exception {
+    // Stub some objects
+    var updateEvent = new UpdateEvent();
+    updateEvent.setEventType(DefineEventType.fromValue(UPDATED_EVENT_TYPE));
+
+    var event = new ProcurementEvent();
+    event.setEventType("RFI"); // Not 'TBD', so rules state cannot update
+
+    // Mock behaviours
+    when(userProfileService.resolveBuyerUserByEmail(PRINCIPAL)).thenReturn(JAGGAER_USER);
+    when(validationService.validateProjectAndEventIds(PROC_PROJECT_ID, PROC_EVENT_ID))
+        .thenReturn(event);
+
+    when(jaggaerService.createUpdateRfx(any()))
+        .thenThrow(new JaggaerApplicationException(1, "NOT OK"));
+
+    // Invoke & assert
+    var ex = assertThrows(IllegalArgumentException.class, () -> procurementEventService
+        .updateProcurementEvent(PROC_PROJECT_ID, PROC_EVENT_ID, updateEvent, PRINCIPAL));
+    assertEquals("Cannot update an existing event type of 'RFI'", ex.getMessage());
+  }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-2394


### Change description ###
Previously could change any event type - rules state once an eventType has changed from `TBD` it cannot then be changed again. Now throws an exception if this is attempted.


### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
