### PR TITLE
Disable TLSv1.3 for all webclients to fix EOF ex

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/AgreementsServiceClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/AgreementsServiceClientConfig.java
@@ -22,10 +22,15 @@ public class AgreementsServiceClientConfig {
   private final AgreementsServiceAPIConfig agreementsServiceAPIConfig;
 
   @Bean("agreementsServiceWebClient")
-  public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager) {
-    var client = new HttpClient(new SslContextFactory.Client(true));
+  public WebClient webClient(final OAuth2AuthorizedClientManager authorizedClientManager) {
 
-    ClientHttpConnector jettyHttpClientConnector = new JettyClientHttpConnector(client);
+    var sslContextFactory = new SslContextFactory.Client(true);
+
+    // SCAT-2463: https://webtide.com/openjdk-11-and-tls-1-3-issues/
+    sslContextFactory.setExcludeProtocols("TLSv1.3");
+
+    ClientHttpConnector jettyHttpClientConnector =
+        new JettyClientHttpConnector(new HttpClient(sslContextFactory));
 
     return WebClient.builder().clientConnector(jettyHttpClientConnector)
         .baseUrl(agreementsServiceAPIConfig.getBaseUrl())

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ConclaveClientConfig.java
@@ -23,9 +23,14 @@ public class ConclaveClientConfig {
 
   @Bean("conclaveWebClient")
   public WebClient webClient(final OAuth2AuthorizedClientManager authorizedClientManager) {
-    var client = new HttpClient(new SslContextFactory.Client(true));
 
-    ClientHttpConnector jettyHttpClientConnector = new JettyClientHttpConnector(client);
+    var sslContextFactory = new SslContextFactory.Client(true);
+
+    // SCAT-2463: https://webtide.com/openjdk-11-and-tls-1-3-issues/
+    sslContextFactory.setExcludeProtocols("TLSv1.3");
+
+    ClientHttpConnector jettyHttpClientConnector =
+        new JettyClientHttpConnector(new HttpClient(sslContextFactory));
 
     return WebClient.builder().clientConnector(jettyHttpClientConnector)
         .baseUrl(conclaveAPIConfig.getBaseUrl()).defaultHeader(ACCEPT, APPLICATION_JSON_VALUE)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/SCAT-2463

### Change description ###
According to https://webtide.com/openjdk-11-and-tls-1-3-issues/ and related Github issues - e.g. https://github.com/eclipse/jetty.project/issues/3891, one possible cause of the intermittent `EOFException` we are seeing being thrown by the webclient, particularly frequently on SIT where testers are hitting the service, is an incompatibility between Jetty on JDK 11 and TLS 1.3.

This change should disable it for all three webclient instances.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
