### PR TITLE
Validate AgreementDetails plus tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -204,7 +209,7 @@
 						</configuration>
 					</execution>
 				</executions>
-			</plugin> 
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
@@ -2,7 +2,9 @@ package uk.gov.crowncommercial.dts.scale.cat.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.util.Collection;
+import javax.validation.Valid;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,13 +19,14 @@ import uk.gov.crowncommercial.dts.scale.cat.service.ProcurementProjectService;
 @RequestMapping(path = "/tenders/projects", produces = APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class ProjectsController extends AbstractRestController {
 
   private final ProcurementProjectService procurementProjectService;
 
   @PostMapping("/agreements")
   public DraftProcurementProject createProcurementProject(
-      @RequestBody final AgreementDetails agreementDetails,
+      @Valid @RequestBody final AgreementDetails agreementDetails,
       final JwtAuthenticationToken authentication) {
 
     var principal = getPrincipalFromJwt(authentication);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/SCAT-2325

### Change description ###
Validate the incoming `AgreementDetails` payload based on generated classes validation annotations (provided by the updated OpenAPI spec).

Both payload properties are required, cannot be null or empty strings and validation thereafter is as follows:
`agreementId`: Must match regex pattern `RM[0-9]{4}([.][0-9]{1,2})?` e.g. `RM3808`, `RM3808.1` etc
`lotId`: Must match regex pattern `([a-zA-Z0-9]+[ ]*)+` e.g. `Lot 1`, `1` etc and be max length of 20 chars

NB: The pattern for the `agreementId` is pretty clear, was less sure about the `lotId` but this seems flexible enough for a simple alphanumeric ID..

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
