### PR TITLE
SCAT-2303 - fix to allow spaces in document upload filenames

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/DocumentKey.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/DocumentKey.java
@@ -19,7 +19,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.DocumentAudienceType
 public class DocumentKey {
 
   public static final Pattern pattern =
-      Pattern.compile("(?<audience>[A-Za-z]+)-(?<fileId>[0-9]+)-(?<fileName>\\S+)");
+      Pattern.compile("(?<audience>[A-Za-z]+)-(?<fileId>[0-9]+)-(?<fileName>[\\s\\S]+)");
 
   // The Jaggaer internal file id
   Integer fileId;

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/model/DocumentKeyTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/model/DocumentKeyTest.java
@@ -26,6 +26,15 @@ class DocumentKeyTest {
   }
 
   @Test
+  void testCreateKeySuccessWhitespaceFilename() {
+    // Decoded key is 'BUYER-1234-test file.txt'
+    DocumentKey key = DocumentKey.fromString("QlVZRVItMTIzNC10ZXN0IGZpbGUudHh0");
+    assertEquals(DocumentAudienceType.BUYER, key.getAudience());
+    assertEquals(1234, key.getFileId());
+    assertEquals("test file.txt", key.getFileName());
+  }
+
+  @Test
   void testCreateKeyFailNonMatchingPattern() {
 
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-2303

### Change description ###

I noticed while testing that the document upload didn't like spaces in filenames (only the download endpoint). This should fix that.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
