### PR TITLE
Validate endDate on publish endpoint - must be in future

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/Application.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/Application.java
@@ -1,10 +1,7 @@
 package uk.gov.crowncommercial.dts.scale.cat;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-
 import lombok.RequiredArgsConstructor;
 
 @SpringBootApplication
@@ -15,7 +12,4 @@ public class Application {
     SpringApplication.run(Application.class, args);
   }
 
-  @Bean public ModelMapper modelMapper() {
-    return new ModelMapper();
-  }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApplicationConfig.java
@@ -1,0 +1,24 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import java.time.Clock;
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ *
+ */
+@Configuration
+public class ApplicationConfig {
+
+  @Bean
+  public Clock utcClock() {
+    return Clock.systemUTC();
+  }
+
+  @Bean
+  public ModelMapper modelMapper() {
+    return new ModelMapper();
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -188,7 +188,7 @@ public class ProcurementEventService {
     var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());
 
     var buyerQuestions =
-        new ArrayList<EvalCriteria>(criteriaService.getEvalCriteria(projectId, eventId, true));
+        new ArrayList<>(criteriaService.getEvalCriteria(projectId, eventId, true));
 
     return tendersAPIModelUtils.buildEventDetail(exportRfxResponse.getRfxSetting(), event,
         buyerQuestions);
@@ -501,6 +501,8 @@ public class ProcurementEventService {
    */
   public void publishEvent(final Integer procId, final String eventId,
       final PublishDates publishDates, final String principal) {
+
+    validationService.validatePublishDates(publishDates);
 
     var jaggaerUserId = userProfileService.resolveBuyerUserByEmail(principal)
         .orElseThrow(() -> new AuthorisationFailureException("Jaggaer user not found")).getUserId();

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationService.java
@@ -1,10 +1,13 @@
 package uk.gov.crowncommercial.dts.scale.cat.service;
 
+import java.time.Clock;
+import java.time.OffsetDateTime;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
 import uk.gov.crowncommercial.dts.scale.cat.model.OCID;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.PublishDates;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
 
 /**
@@ -15,6 +18,7 @@ import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
 public class ValidationService {
 
   private final RetryableTendersDBDelegate retryableTendersDBDelegate;
+  private final Clock clock;
 
   /**
    * Validate the project and event IDs and return the {@link ProcurementEvent} entity
@@ -49,13 +53,29 @@ public class ValidationService {
    * @param eventId
    * @return an OCID
    */
-  public OCID validateEventId(String eventId) {
+  public OCID validateEventId(final String eventId) {
     try {
       return OCID.fromString(eventId);
     } catch (Exception e) {
       throw new IllegalArgumentException(
           "Event ID '" + eventId + "' is not in the expected format");
     }
+  }
+
+  /**
+   * Validates the publish event dates (Note: startDate currently ignored so not validated)
+   *
+   * @param publishDates
+   * @throws IllegalArgumentException if the endDate is not in the future
+   */
+  public void validatePublishDates(final PublishDates publishDates) {
+
+    var now = OffsetDateTime.now(clock);
+
+    if (!publishDates.getEndDate().isAfter(now)) {
+      throw new IllegalArgumentException("endDate must be in the future");
+    }
+
   }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/SCAT-3241


### Change description ###
Validate publish endpoint `endDate` to throw a `400` if the date timer provided is not in the future.  Added a couple of tests to for the new validation service method - I have the remainder of the publish event tests on a separate branch but it includes some other refactorings that weren't quite complete.
This also introduces a `Clock` instance bean - we could extend usage of this across the codebase.  The advantage is it can then be replaced with a fixed instance for testing purposes so we're not reliant on "now".


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
