### PR TITLE
Bugfix/scat 3398 republish event

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -187,8 +187,7 @@ public class ProcurementEventService {
     var event = validationService.validateProjectAndEventIds(projectId, eventId);
     var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());
 
-    var buyerQuestions =
-        new ArrayList<>(criteriaService.getEvalCriteria(projectId, eventId, true));
+    var buyerQuestions = new ArrayList<>(criteriaService.getEvalCriteria(projectId, eventId, true));
 
     return tendersAPIModelUtils.buildEventDetail(exportRfxResponse.getRfxSetting(), event,
         buyerQuestions);
@@ -505,11 +504,13 @@ public class ProcurementEventService {
     var jaggaerUserId = userProfileService.resolveBuyerUserByEmail(principal)
         .orElseThrow(() -> new AuthorisationFailureException("Jaggaer user not found")).getUserId();
 
-    var event = getEvent(procId, eventId);
+    var procurementEvent = validationService.validateProjectAndEventIds(procId, eventId);
+    var exportRfxResponse = jaggaerService.getRfx(procurementEvent.getExternalEventId());
+    var status = jaggaerAPIConfig.getRfxStatusToTenderStatus()
+        .get(exportRfxResponse.getRfxSetting().getStatusCode());
 
-    if (TenderStatus.PLANNED == event.getOCDS().getStatus()) {
+    if (TenderStatus.PLANNED == status) {
       validationService.validatePublishDates(publishDates);
-      var procurementEvent = validationService.validateProjectAndEventIds(procId, eventId);
       jaggaerService.publishRfx(procurementEvent, publishDates, jaggaerUserId);
     } else {
       throw new IllegalArgumentException(


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-3398

### Change description ###

Instead of throwing 500 error will now throw 400 if you try and re-publish an event that is already published

### Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed)
