### PR TITLE
SCAT-3519 - added get events for project endpoint

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
@@ -2,6 +2,7 @@ package uk.gov.crowncommercial.dts.scale.cat.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.util.Collection;
+import java.util.List;
 import javax.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,16 @@ public class EventsController extends AbstractRestController {
 
   private final ProcurementEventService procurementEventService;
   private final DocGenService docGenService;
+
+  @GetMapping
+  public List<EventSummary> getEventsForProject(@PathVariable("procID") final Integer procId,
+      final JwtAuthenticationToken authentication) {
+
+    var principal = getPrincipalFromJwt(authentication);
+    log.info("getEventsForProject invoked on behalf of principal: {}", principal);
+
+    return procurementEventService.getEventsForProject(procId);
+  }
 
   @PostMapping
   public EventSummary createProcurementEvent(@PathVariable("procID") final Integer procId,

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/ProcurementEventRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/ProcurementEventRepo.java
@@ -1,6 +1,7 @@
 package uk.gov.crowncommercial.dts.scale.cat.repo;
 
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
@@ -13,4 +14,6 @@ public interface ProcurementEventRepo extends JpaRepository<ProcurementEvent, In
 
   Optional<ProcurementEvent> findProcurementEventByIdAndOcdsAuthorityNameAndOcidPrefix(
       Integer eventIdKey, String ocdsAuthorityName, String ocidPrefix);
+
+  Set<ProcurementEvent> findByProjectId(Integer projectId);
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
@@ -92,6 +92,11 @@ public class RetryableTendersDBDelegate {
     return documentTemplateRepo.findByEventType(eventType);
   }
 
+  @TendersDBRetryable
+  public Set<ProcurementEvent> findProcurementEventsByProjectId(final Integer projectId) {
+    return procurementEventRepo.findByProjectId(projectId);
+  }
+
   /**
    * Catch-all recovery method to wrap original exception in {@link ExhaustedRetryException} and
    * re-throw. Note - signature must match retried method.

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
@@ -320,4 +320,16 @@ class EventsControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is("400 BAD_REQUEST")))
         .andExpect(jsonPath("$.errors[0].title", is("Validation error processing the request")));
   }
+
+  @Test
+  void getEvents_200_OK() throws Exception {
+
+    mockMvc
+        .perform(get(EVENTS_PATH, PROC_PROJECT_ID).with(validJwtReqPostProcessor)
+            .accept(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON));
+
+    verify(procurementEventService, times(1)).getEventsForProject(PROC_PROJECT_ID);
+  }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-3519

### Change description ###

Implement endpoint to return EventSummaries for all events on a Project - `/tenders/projects/{proc-id}/events`

This requires pulling data from Jaggaer and the Tenders DB.

I initially was going to implement the other way around - i.e. retrieve all events from Jaggaer in a single call (a new one - to `/esop/jint/api/public/ja/v1/rfxs?flt=rfxId==rfi_39864`) and then make individual calls to the database to retrieve the necessary data.

However, given where we are, in the interests of brevity (and not anticipating many events on a project) - and the fact that would cause merge conflicts with Sudhakars get project list code - decided to take this simpler route - which is pretty lightweight in terms of code added. Can always revisit if necessary.


### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
