### PR TITLE
Release latest to SIT

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/mapper/DependencyMapper.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/mapper/DependencyMapper.java
@@ -1,0 +1,45 @@
+package uk.gov.crowncommercial.dts.scale.cat.mapper;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.cat.model.agreements.Requirement;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.DependencyType;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.QuestionDependancy;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.QuestionNonOCDSDependency;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.QuestionRelationship;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.RelationshipType;
+
+/**
+ * Encapsulates conversion logic between DTOs and Entities.
+ */
+@RequiredArgsConstructor
+@Component
+public class DependencyMapper {
+
+	public QuestionNonOCDSDependency convertToQuestionNonOCDSDependency(final Requirement requirement) {
+
+		final var questionNonOCDSDependency = new QuestionNonOCDSDependency();
+		final var dependency = requirement.getNonOCDS().getDependency();
+		if (Objects.nonNull(dependency.getConditional())) {
+			questionNonOCDSDependency.conditional(new QuestionDependancy()
+					.dependencyType(
+							DependencyType.fromValue(dependency.getConditional().getDependencyType().getValue()))
+					.dependencyValue(dependency.getConditional().getDependencyValue())
+					.dependentOnId(dependency.getConditional().getDependentOnID()));
+		}
+		if (Objects.nonNull(dependency.getRelationships())) {
+			final var relationshipList = dependency.getRelationships().stream()
+					.map(relationships -> new QuestionRelationship()
+					.dependentOnId(relationships.getDependentOnID())
+					.relationshipType(RelationshipType.fromValue(relationships.getRelationshipType()))
+					).collect(Collectors.toList());
+			questionNonOCDSDependency.relationships(relationshipList);
+		}
+		return questionNonOCDSDependency;
+	}
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Conditional.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Conditional.java
@@ -1,0 +1,14 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.agreements;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class Conditional {
+  String dependentOnID;
+  DependencyType dependencyType;
+  String dependencyValue;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Dependency.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Dependency.java
@@ -1,0 +1,15 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.agreements;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class Dependency{
+  Conditional conditional;
+  List<Relationships> relationships;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/DependencyType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/DependencyType.java
@@ -1,0 +1,49 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.agreements;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Type of relationship to dependent field   * GreaterThan (Dependent value greater than dependencyValue)    * EqualTo (Dependent value equal to the dependencyValue)   * LessThan (Dependent value less than the dependency value)   * Inside (Dependent value inside a range or period)   * Outside (Dependent value outside a range or period)   * NotNull (Any Dependent value has been provided)
+ */
+public enum DependencyType {
+
+	GREATERTHAN("GreaterThan"),
+
+	EQUALTO("EqualTo"),
+
+	LESSTHAN("LessThan"),
+
+	INSIDE("Inside"),
+
+	OUTSIDE("Outside"),
+
+	NOTNULL("NotNull");
+
+	private String value;
+
+	DependencyType(final String value) {
+		this.value = value;
+	}
+
+	@JsonValue
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(value);
+	}
+
+	@JsonCreator
+	public static DependencyType fromValue(final String value) {
+		for (final DependencyType b : DependencyType.values()) {
+			if (b.value.equals(value)) {
+				return b;
+			}
+		}
+		throw new IllegalArgumentException("Unexpected value '" + value + "'");
+	}
+}
+

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Relationships.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Relationships.java
@@ -1,0 +1,14 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.agreements;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class Relationships{
+  String dependentOnID;
+  String relationshipType;
+}
+

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Requirement.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/agreements/Requirement.java
@@ -48,6 +48,7 @@ public class Requirement {
     Boolean multiAnswer;
     Integer order;
     Integer length;
+    Dependency dependency;
 
     @NonFinal
     List<Option> options; // Maps to QuestionNonOCDSOptions

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/CriteriaService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/CriteriaService.java
@@ -18,6 +18,7 @@ import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.AgreementsServiceApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
+import uk.gov.crowncommercial.dts.scale.cat.mapper.DependencyMapper;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.Requirement;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.RequirementGroup;
@@ -43,6 +44,7 @@ public class CriteriaService {
   private final RetryableTendersDBDelegate retryableTendersDBDelegate;
   private final JaggaerAPIConfig jaggaerAPIConfig;
   private final WebClient jaggaerWebClient;
+  private final DependencyMapper dependencyMapper;
 
   public Set<EvalCriteria> getEvalCriteria(final Integer projectId, final String eventId,
       final boolean populateGroups) {
@@ -250,6 +252,9 @@ public class CriteriaService {
             new QuestionNonOCDSOptions().value(o.getValue())
                      .selected(o.getSelect() == null? Boolean.FALSE:o.getSelect())
                 .text(o.getText())).collect(Collectors.toList()));
+    if (Objects.nonNull(r.getNonOCDS().getDependency())) {
+      questionNonOCDS.dependency(dependencyMapper.convertToQuestionNonOCDSDependency(r));
+    }
 
     var description = r.getOcds().getDescription();
     if (Objects.nonNull(description) && description.contains(END_DATE)) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -266,7 +266,7 @@ public class ProcurementEventService {
       }
 
       if (ASSESSMENT_EVENT_TYPES.contains(updateEvent.getEventType())
-          && updateEvent.getAssessmentId() == null) {
+          && updateEvent.getAssessmentId() == null && event.getAssessmentId() == null) {
         createAssessment = true;
       }
 
@@ -584,8 +584,7 @@ public class ProcurementEventService {
    */
   public List<EventSummary> getEventsForProject(final Integer projectId) {
 
-    var events =
-        retryableTendersDBDelegate.findProcurementEventsByProjectId(projectId);
+    var events = retryableTendersDBDelegate.findProcurementEventsByProjectId(projectId);
 
     return events.stream().map(event -> {
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/CriteriaServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/CriteriaServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.reactive.function.client.WebClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.mapper.DependencyMapper;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.DataTemplate;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.Requirement.Option;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.TemplateCriteria;
@@ -51,6 +52,9 @@ class CriteriaServiceTest {
 
   @MockBean
   private WebClient jaggaerWebClient;
+
+  @MockBean
+  private DependencyMapper dependencyMapper;
 
   @Autowired
   private CriteriaService criteriaService;


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-3504 (bugfix to update event)
SCAT-2616 dependency mapping from AS

Test team were going to raise a bug for SCAT-3504 (adding assessmentId to the procurement event table).  I said I think it's been fixed, just not on SIT yet..

### Change description ###
As above


### Does this PR introduce a breaking change?

- [x] Yes - @sudhakar-reddy-konda Could you do the necessary AS data update?
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
