### PR TITLE
SCAT-3835 - persist assessmentId on update event (#176)

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -300,7 +300,7 @@ public class ProcurementEventService {
     if (updateDB) {
       event.setUpdatedAt(Instant.now());
       event.setUpdatedBy(principal);
-
+      event.setAssessmentId(returnAssessmentId);
       retryableTendersDBDelegate.save(event);
     }
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -514,6 +514,7 @@ class ProcurementEventServiceTest {
     verify(procurementEventRepo).save(captor.capture());
     assertEquals(UPDATED_EVENT_TYPE_CAP_ASS, captor.getValue().getEventType());
     assertEquals(PRINCIPAL, captor.getValue().getUpdatedBy());
+    assertEquals(ASSESSMENT_ID, captor.getValue().getAssessmentId());
     verify(jaggaerService, times(0)).createUpdateRfx(any(), eq(OperationCode.CREATEUPDATE));
   }
 


### PR DESCRIPTION
SCAT-3835 - persist assessmentId on update event

### JIRA link (if applicable) ###

SCAT-3835

### Change description ###

Bugfix


### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
