### PR TITLE
Fix get event / type assessment bug

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -216,10 +216,10 @@ public class ProcurementEventService {
     var event = validationService.validateProjectAndEventIds(projectId, eventId);
     var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());
 
-    var buyerQuestions = new ArrayList<>(criteriaService.getEvalCriteria(projectId, eventId, true));
-
     return tendersAPIModelUtils.buildEventDetail(exportRfxResponse.getRfxSetting(), event,
-        buyerQuestions);
+        ASSESSMENT_EVENT_TYPES.contains(DefineEventType.fromValue(event.getEventType()))
+            ? Collections.emptySet()
+            : criteriaService.getEvalCriteria(projectId, eventId, true));
   }
 
   /**

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.crowncommercial.dts.scale.cat.utils;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -72,7 +73,7 @@ public class TendersAPIModelUtils {
   }
 
   public EventDetail buildEventDetail(final RfxSetting rfxSetting,
-      final ProcurementEvent procurementEvent, final List<EvalCriteria> buyerQuestions) {
+      final ProcurementEvent procurementEvent, final Collection<EvalCriteria> buyerQuestions) {
     var eventDetail = new EventDetail();
 
     var agreementDetails = new AgreementDetails();
@@ -85,7 +86,9 @@ public class TendersAPIModelUtils {
     var eventDetailNonOCDS = new EventDetailNonOCDS();
     eventDetailNonOCDS.setEventType(ViewEventType.fromValue(procurementEvent.getEventType()));
     eventDetailNonOCDS.setEventSupportId(procurementEvent.getExternalReferenceId());
-    eventDetailNonOCDS.setBuyerQuestions(buyerQuestions);
+    if (buyerQuestions != null && !buyerQuestions.isEmpty()) {
+      eventDetailNonOCDS.setBuyerQuestions(List.copyOf(buyerQuestions));
+    }
     eventDetail.setNonOCDS(eventDetailNonOCDS);
 
     // OCDS

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -3,8 +3,7 @@ package uk.gov.crowncommercial.dts.scale.cat.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import java.time.Duration;
 import java.util.Arrays;
@@ -716,43 +715,61 @@ class ProcurementEventServiceTest {
   }
 
   @Test
-  void testGetEvent() throws Exception {
-
-    var procurementProject =
-        ProcurementProject.builder().caNumber(CA_NUMBER).lotNumber(LOT_NUMBER).build();
-    var procurementEvent = ProcurementEvent.builder().project(procurementProject).eventType("RFI")
-        .externalEventId(RFX_ID).externalReferenceId(RFX_REF_CODE).build();
-
-    var rfxSetting = RfxSetting.builder().statusCode(100).rfxId(RFX_ID)
-        .shortDescription(ORIGINAL_EVENT_NAME).longDescription(DESCRIPTION).build();
-    var rfxResponse = new ExportRfxResponse();
-    rfxResponse.setRfxSetting(rfxSetting);
+  void testGetEventNonAssessmentType() throws Exception {
 
     var criterion = new EvalCriteria();
     criterion.setTitle(CRITERION_TITLE);
     var buyerQuestions = new HashSet<EvalCriteria>();
     buyerQuestions.add(criterion);
 
+    when(criteriaService.getEvalCriteria(PROC_PROJECT_ID, PROC_EVENT_ID, true))
+        .thenReturn(buyerQuestions);
+
+    var eventDetail = testGetEventHelper(ViewEventType.RFI);
+
+    // Additional assertions / verifications
+    assertEquals(CRITERION_TITLE,
+        eventDetail.getNonOCDS().getBuyerQuestions().stream().findFirst().get().getTitle());
+    verify(criteriaService).getEvalCriteria(PROC_PROJECT_ID, PROC_EVENT_ID, true);
+  }
+
+  @Test
+  void testGetEventAssessmentType() throws Exception {
+    testGetEventHelper(ViewEventType.FCA);
+
+    verify(criteriaService, never()).getEvalCriteria(anyInt(), anyString(), anyBoolean());
+  }
+
+  EventDetail testGetEventHelper(final ViewEventType eventType) {
+    var procurementProject =
+        ProcurementProject.builder().caNumber(CA_NUMBER).lotNumber(LOT_NUMBER).build();
+    var procurementEvent =
+        ProcurementEvent.builder().project(procurementProject).eventType(eventType.name())
+            .externalEventId(RFX_ID).externalReferenceId(RFX_REF_CODE).build();
+
+    var rfxSetting = RfxSetting.builder().statusCode(100).rfxId(RFX_ID)
+        .shortDescription(ORIGINAL_EVENT_NAME).longDescription(DESCRIPTION).build();
+    var rfxResponse = new ExportRfxResponse();
+    rfxResponse.setRfxSetting(rfxSetting);
+
     // Mock behaviours
     when(validationService.validateProjectAndEventIds(PROC_PROJECT_ID, PROC_EVENT_ID))
         .thenReturn(procurementEvent);
     when(jaggaerService.getRfx(RFX_ID)).thenReturn(rfxResponse);
-    when(criteriaService.getEvalCriteria(PROC_PROJECT_ID, PROC_EVENT_ID, true))
-        .thenReturn(buyerQuestions);
 
-    var response = procurementEventService.getEvent(PROC_PROJECT_ID, PROC_EVENT_ID);
+    var eventDetail = procurementEventService.getEvent(PROC_PROJECT_ID, PROC_EVENT_ID);
 
     // Verify
-    assertEquals(CRITERION_TITLE,
-        response.getNonOCDS().getBuyerQuestions().stream().findFirst().get().getTitle());
-    assertEquals(ViewEventType.RFI, response.getNonOCDS().getEventType());
-    assertEquals(RFX_REF_CODE, response.getNonOCDS().getEventSupportId());
+    assertEquals(eventType, eventDetail.getNonOCDS().getEventType());
+    assertEquals(RFX_REF_CODE, eventDetail.getNonOCDS().getEventSupportId());
 
-    assertEquals(RFX_ID, response.getOCDS().getId());
-    assertEquals(ORIGINAL_EVENT_NAME, response.getOCDS().getTitle());
-    assertEquals(DESCRIPTION, response.getOCDS().getDescription());
-    assertEquals(TenderStatus.PLANNED, response.getOCDS().getStatus());
-    assertEquals(AwardCriteria.RATEDCRITERIA, response.getOCDS().getAwardCriteria());
+    assertEquals(RFX_ID, eventDetail.getOCDS().getId());
+    assertEquals(ORIGINAL_EVENT_NAME, eventDetail.getOCDS().getTitle());
+    assertEquals(DESCRIPTION, eventDetail.getOCDS().getDescription());
+    assertEquals(TenderStatus.PLANNED, eventDetail.getOCDS().getStatus());
+    assertEquals(AwardCriteria.RATEDCRITERIA, eventDetail.getOCDS().getAwardCriteria());
+
+    return eventDetail;
   }
 
   @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/SCAT-4059

### Change description ###
Fixed bug whereby request was made to AS for data template for all event types, including `FCA` and `DAA` that do not have one (resulting in a `500` error).

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
