### PR TITLE
Feature/scat 3509 ca add suppliers

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
@@ -85,15 +85,16 @@ public class EventsController extends AbstractRestController {
   }
 
   @PostMapping("/{eventID}/suppliers")
-  public OrganizationReference addSupplier(@PathVariable("procID") final Integer procId,
+  public Collection<OrganizationReference> addSupplier(@PathVariable("procID") final Integer procId,
       @PathVariable("eventID") final String eventId,
-      @RequestBody final OrganizationReference organizationReference,
+      @RequestBody final Collection<OrganizationReference> organizationReferences,
       final JwtAuthenticationToken authentication) {
 
     var principal = getPrincipalFromJwt(authentication);
     log.info("getSuppliers invoked on behalf of principal: {}", principal);
 
-    return procurementEventService.addSupplier(procId, eventId, organizationReference);
+    return procurementEventService.addSuppliers(procId, eventId, organizationReferences, false,
+        principal);
   }
 
   @DeleteMapping("/{eventID}/suppliers/{supplierID}")
@@ -105,7 +106,7 @@ public class EventsController extends AbstractRestController {
     var principal = getPrincipalFromJwt(authentication);
     log.info("deleteSupplier invoked on behalf of principal: {}", principal);
 
-    procurementEventService.deleteSupplier(procId, eventId, supplierId);
+    procurementEventService.deleteSupplier(procId, eventId, supplierId, principal);
 
     return "OK";
   }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementEvent.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementEvent.java
@@ -1,6 +1,7 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.entity;
 
 import java.time.Instant;
+import java.util.Set;
 import javax.persistence.*;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
@@ -32,6 +33,10 @@ public class ProcurementEvent {
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "project_id")
   ProcurementProject project;
+
+  @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "event_id")
+  Set<SupplierSelection> capabilityAssessmentSuppliers;
 
   @Column(name = "ocds_authority_name")
   String ocdsAuthorityName;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/SupplierSelection.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/SupplierSelection.java
@@ -1,0 +1,38 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.entity;
+
+import java.time.Instant;
+import javax.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+/**
+ *
+ */
+@Entity
+@Table(name = "supplier_selections")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SupplierSelection {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "supplier_selection_id")
+  Integer id;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "organisation_mapping_id")
+  OrganisationMapping organisationMapping;
+
+  @Column(name = "event_id")
+  Integer eventId;
+
+  @Column(name = "created_by", updatable = false)
+  String createdBy;
+
+  @Column(name = "created_at", updatable = false)
+  Instant createdAt;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
@@ -34,6 +34,7 @@ public class RetryableTendersDBDelegate {
   private final CalculationBaseRepo calculationBaseRepo;
   private final AssessmentResultRepo assessmentResultRepo;
   private final ProjectUserMappingRepo projectUserMappingRepo;
+  private final SupplierSelectionRepo supplierSelectionRepo;
 
   @TendersDBRetryable
   public ProcurementProject save(final ProcurementProject procurementProject) {
@@ -208,17 +209,17 @@ public class RetryableTendersDBDelegate {
 
   @TendersDBRetryable
   public void delete(final ProjectUserMapping projectUserMapping) {
-     projectUserMappingRepo.delete(projectUserMapping);
+    projectUserMappingRepo.delete(projectUserMapping);
   }
 
   @TendersDBRetryable
   public void deleteAll(final List<ProjectUserMapping> projectUserMappings) {
-     projectUserMappingRepo.deleteAll(projectUserMappings);
+    projectUserMappingRepo.deleteAll(projectUserMappings);
   }
 
   @TendersDBRetryable
   public void saveAll(final List<ProjectUserMapping> projectUserMappings) {
-     projectUserMappingRepo.saveAll(projectUserMappings);
+    projectUserMappingRepo.saveAll(projectUserMappings);
   }
 
   @TendersDBRetryable
@@ -230,6 +231,12 @@ public class RetryableTendersDBDelegate {
   public Set<ProjectUserMapping> findProjectUserMappingByUserId(final String userId) {
     return projectUserMappingRepo.findByUserId(userId);
   }
+
+  @TendersDBRetryable
+  public void delete(final SupplierSelection supplierSelection) {
+    supplierSelectionRepo.delete(supplierSelection);
+  }
+
   /**
    * Catch-all recovery method to wrap original exception in {@link ExhaustedRetryException} and
    * re-throw. Note - signature must match retried method.

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/SupplierSelectionRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/SupplierSelectionRepo.java
@@ -1,0 +1,8 @@
+package uk.gov.crowncommercial.dts.scale.cat.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.SupplierSelection;
+
+public interface SupplierSelectionRepo extends JpaRepository<SupplierSelection, Integer> {
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -24,8 +24,10 @@ import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationExceptio
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
 import uk.gov.crowncommercial.dts.scale.cat.model.DocumentAttachment;
 import uk.gov.crowncommercial.dts.scale.cat.model.DocumentKey;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementProject;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.SupplierSelection;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.Tender;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.*;
@@ -331,62 +333,76 @@ public class ProcurementEventService {
     log.debug("Get suppliers for event '{}'", eventId);
 
     var event = validationService.validateProjectAndEventIds(procId, eventId);
-    var existingRfx = jaggaerService.getRfx(event.getExternalEventId());
-    var orgs = new ArrayList<OrganizationReference>();
 
-    if (existingRfx.getSuppliersList().getSupplier() != null) {
-      existingRfx.getSuppliersList().getSupplier().stream().map(s -> {
-
-        var om = retryableTendersDBDelegate
-            .findOrganisationMappingByExternalOrganisationId(s.getCompanyData().getId())
-            .orElseThrow(() -> new IllegalArgumentException(
-                String.format(SUPPLIER_NOT_FOUND_MSG, s.getCompanyData().getId())));
-
-        var org = new OrganizationReference();
-        org.setId(String.valueOf(om.getOrganisationId()));
-        org.setName(s.getCompanyData().getName());
-        return org;
-      }).forEachOrdered(orgs::add);
+    if (isAssessmentEvent(event)) {
+      log.debug("Event {} is an Assessment Type {}, retrieve suppliers from Tenders DB",
+          event.getId(), event.getEventType());
+      return getSuppliersFromTendersDB(event);
+    } else {
+      log.debug("Event {} is not an Assessment Type {}, retrieve suppliers from Jaggaer",
+          event.getId(), event.getEventType());
+      return getSuppliersFromJaggaer(event);
     }
-
-    return orgs;
   }
 
   /**
-   * Add a supplier to an event.
+   * Add/Overwrite suppliers on an Event.
    *
-   * Jaggaer will add any suppliers it does not already have associated to the event, so only those
-   * suppliers need to be included.
+   * If it is an Assessment Event Type, suppliers will only be added in the Tenders DB, otherwise
+   * updates will only be in Jaggaer.
    *
    * @param procId
    * @param eventId
-   * @param organisationReference
+   * @param organisationReferences
+   * @param overwrite if <code>true</code> will replace the list of suppliers, otherwise it will
+   *        just add to the list.
    * @return
    */
-  public OrganizationReference addSupplier(final Integer procId, final String eventId,
-      final OrganizationReference organisationReference) {
-
-    log.debug("Add supplier '{}' to event '{}'", organisationReference, eventId);
+  public Collection<OrganizationReference> addSuppliers(final Integer procId, final String eventId,
+      final Collection<OrganizationReference> organisationReferences, final boolean overwrite,
+      final String principal) {
 
     var event = validationService.validateProjectAndEventIds(procId, eventId);
 
-    var om = retryableTendersDBDelegate
-        .findOrganisationMappingByOrganisationId(organisationReference.getId())
-        .orElseThrow(() -> new IllegalArgumentException(
-            String.format(SUPPLIER_NOT_FOUND_MSG, organisationReference.getId())));
+    var supplierOrgIds = organisationReferences.stream().map(OrganizationReference::getId)
+        .collect(Collectors.toSet());
 
-    var companyData = CompanyData.builder().id(om.getExternalOrganisationId()).build();
-    var supplier = Supplier.builder().companyData(companyData).build();
-    var suppliersList = SuppliersList.builder().supplier(Arrays.asList(supplier)).build();
+    var supplierOrgMappings =
+        retryableTendersDBDelegate.findOrganisationMappingByOrganisationIdIn(supplierOrgIds);
 
-    // Build Rfx and update
-    var rfxSetting = RfxSetting.builder().rfxId(event.getExternalEventId())
-        .rfxReferenceCode(event.getExternalReferenceId()).build();
-    var rfx = Rfx.builder().rfxSetting(rfxSetting).suppliersList(suppliersList).build();
-    jaggaerService.createUpdateRfx(rfx, OperationCode.CREATEUPDATE);
+    // Validate suppliers exist in Organisation Mapping Table
+    if (supplierOrgMappings.size() != organisationReferences.size()) {
 
-    return organisationReference;
+      var missingSuppliers = new ArrayList<String>();
+      organisationReferences.stream().forEach(or -> {
+        if (supplierOrgMappings.parallelStream()
+            .filter(som -> som.getOrganisationId().equals(or.getId())).findFirst().isEmpty()) {
+          missingSuppliers.add(or.getId());
+        }
+      });
 
+      if (!missingSuppliers.isEmpty()) {
+        throw new ResourceNotFoundException(String.format(
+            "The following suppliers are not present in the Organisation Mappings, so unable to add them: %s",
+            missingSuppliers));
+      }
+    }
+
+    /*
+     * If Event is an Assessment Type, suppliers are stored in the Tenders DB only, otherwise they
+     * are stored in Jaggaer.
+     */
+    if (isAssessmentEvent(event)) {
+      log.debug("Event {} is an Assessment Type {}, add suppliers to Tenders DB",
+          event.getEventID(), event.getEventType());
+      addSuppliersToTendersDB(event, supplierOrgMappings, overwrite, principal);
+    } else {
+      log.debug("Event {} is an not an Assessment Type {}, add suppliers to Jaggaer", event.getId(),
+          event.getEventType());
+      addSuppliersToJaggaer(event, supplierOrgMappings, overwrite);
+    }
+
+    return organisationReferences;
   }
 
   /**
@@ -400,7 +416,7 @@ public class ProcurementEventService {
    * @param organisationId
    */
   public void deleteSupplier(final Integer procId, final String eventId,
-      final String organisationId) {
+      final String organisationId, final String principal) {
 
     log.debug("Delete supplier '{}' from event '{}'", organisationId, eventId);
 
@@ -411,19 +427,19 @@ public class ProcurementEventService {
         .orElseThrow(() -> new IllegalArgumentException(
             String.format(SUPPLIER_NOT_FOUND_MSG, organisationId)));
 
-    // Get all current suppliers on Rfx and remove the one we want to delete
-    var existingRfx = jaggaerService.getRfx(event.getExternalEventId());
-    List<Supplier> updatedSuppliersList = existingRfx.getSuppliersList().getSupplier().stream()
-        .filter(s -> !s.getCompanyData().getId().equals(om.getExternalOrganisationId()))
-        .collect(Collectors.toList());
-    var suppliersList = SuppliersList.builder().supplier(updatedSuppliersList).build();
-
-    // Build Rfx and update
-    var rfxSetting = RfxSetting.builder().rfxId(event.getExternalEventId())
-        .rfxReferenceCode(event.getExternalReferenceId()).build();
-    var rfx = Rfx.builder().rfxSetting(rfxSetting).suppliersList(suppliersList).build();
-    jaggaerService.createUpdateRfx(rfx, OperationCode.UPDATE_RESET);
-
+    /*
+     * If Event is an Assessment Type, suppliers are stored in the Tenders DB only, otherwise they
+     * are stored in Jaggaer.
+     */
+    if (isAssessmentEvent(event)) {
+      log.debug("Event {} is an Assessment Type {}, delete supplier from Tenders DB", event.getId(),
+          event.getEventType());
+      deleteSupplierFromTendersDB(event, om, principal);
+    } else {
+      log.debug("Event {} is an Assessment Type {}, delete supplier from Jaggaer", event.getId(),
+          event.getEventType());
+      deleteSupplierFromJaggaer(event, om);
+    }
   }
 
   private String getDefaultEventTitle(final String projectName, final String eventType) {
@@ -606,6 +622,174 @@ public class ProcurementEventService {
           Optional.ofNullable(event.getExternalEventId()),
           ViewEventType.fromValue(event.getEventType()), statusCode, EVENT_STAGE, Optional.empty());
     }).collect(Collectors.toList());
+  }
+
+  /**
+   * Is the event an Assessment Event (e.g. FCA, DAA)?
+   *
+   * @param event
+   * @return
+   */
+  private boolean isAssessmentEvent(final ProcurementEvent event) {
+    return (ASSESSMENT_EVENT_TYPES.contains(event.getEventType()));
+  }
+
+  /**
+   * Add/overwrite suppliers in Tenders DB.
+   *
+   * @param event
+   * @param supplierOrgMappings
+   * @param overwrite
+   */
+  private void addSuppliersToTendersDB(final ProcurementEvent event,
+      final Set<OrganisationMapping> supplierOrgMappings, final boolean overwrite,
+      final String principal) {
+
+    if (overwrite) {
+      event.getCapabilityAssessmentSuppliers().clear();
+    }
+
+    var suppliers = event.getCapabilityAssessmentSuppliers();
+    supplierOrgMappings.stream().forEach(org -> {
+      if (suppliers.stream().noneMatch(s -> Objects
+          .equals(s.getOrganisationMapping().getOrganisationId(), org.getOrganisationId()))) {
+        log.debug("Creating new SupplierSelection record for organisation [{}]",
+            org.getOrganisationId());
+        var selection = SupplierSelection.builder().organisationMapping(org).eventId(event.getId())
+            .createdAt(Instant.now()).createdBy(principal).build();
+        event.getCapabilityAssessmentSuppliers().add(selection);
+      }
+    });
+    retryableTendersDBDelegate.save(event);
+  }
+
+  /**
+   * Add/overwrite suppliers in Jaggaer.
+   *
+   * @param event
+   * @param supplierOrgMappings
+   * @param overwrite
+   */
+  private void addSuppliersToJaggaer(final ProcurementEvent event,
+      final Set<OrganisationMapping> supplierOrgMappings, final boolean overwrite) {
+
+    OperationCode operationCode;
+    if (overwrite) {
+      operationCode = OperationCode.UPDATE_RESET;
+    } else {
+      operationCode = OperationCode.CREATEUPDATE;
+    }
+
+    var suppliersList = supplierOrgMappings.stream().map(org -> {
+      var companyData = CompanyData.builder().id(org.getExternalOrganisationId()).build();
+      return Supplier.builder().companyData(companyData).build();
+    }).collect(Collectors.toList());
+
+    // Build Rfx and update
+    var rfxSetting = RfxSetting.builder().rfxId(event.getExternalEventId())
+        .rfxReferenceCode(event.getExternalReferenceId()).build();
+    var rfx = Rfx.builder().rfxSetting(rfxSetting)
+        .suppliersList(SuppliersList.builder().supplier(suppliersList).build()).build();
+    jaggaerService.createUpdateRfx(rfx, operationCode);
+  }
+
+  /**
+   * Get suppliers on an event from Tenders DB.
+   *
+   * @param event
+   * @return
+   */
+  private List<OrganizationReference> getSuppliersFromTendersDB(final ProcurementEvent event) {
+
+    return event.getCapabilityAssessmentSuppliers().stream().map(s -> {
+
+      // TODO - Conclave does not work with DUNS numbers (which we have in organisation_mapping
+      // table)
+      // Nick raised this with Nanu who was going to speak to Brickendon as they should support
+      // lookup by DUNS number. This can be reinstated when that is fixed in Conclave.
+      // OrganisationProfileResponseInfo org = conclaveService
+      // .getOrganisation(s.getOrganisationMapping().getOrganisationId()).orElseThrow(
+      // () -> new ResourceNotFoundException(String.format(SUPPLIER_NOT_FOUND_CONCLAVE_MSG,
+      // s.getOrganisationMapping().getOrganisationId())));
+
+      var orgRef = new OrganizationReference();
+      orgRef.setId(String.valueOf(s.getOrganisationMapping().getOrganisationId()));
+      // orgRef.setName(org.getIdentifier().getLegalName()); // see comment above
+      return orgRef;
+    }).collect(Collectors.toList());
+  }
+
+  /**
+   * Get suppliers on an event from Jaggaer.
+   *
+   * @param event
+   * @return
+   */
+  private List<OrganizationReference> getSuppliersFromJaggaer(final ProcurementEvent event) {
+
+    var existingRfx = jaggaerService.getRfx(event.getExternalEventId());
+    var orgs = new ArrayList<OrganizationReference>();
+
+    if (existingRfx.getSuppliersList().getSupplier() != null) {
+      existingRfx.getSuppliersList().getSupplier().stream().map(s -> {
+
+        var om = retryableTendersDBDelegate
+            .findOrganisationMappingByExternalOrganisationId(s.getCompanyData().getId())
+            .orElseThrow(() -> new IllegalArgumentException(
+                String.format(SUPPLIER_NOT_FOUND_MSG, s.getCompanyData().getId())));
+
+        var org = new OrganizationReference();
+        org.setId(String.valueOf(om.getOrganisationId()));
+        org.setName(s.getCompanyData().getName());
+        return org;
+      }).forEachOrdered(orgs::add);
+    }
+
+    return orgs;
+  }
+
+  /**
+   * Delete supplier from Tenders DB.
+   *
+   * @param event
+   * @param supplierOrgMappings
+   * @param overwrite
+   */
+  private void deleteSupplierFromTendersDB(final ProcurementEvent event,
+      final OrganisationMapping supplierOrgMapping, final String principal) {
+
+    event.setUpdatedAt(Instant.now());
+    event.setUpdatedBy(principal);
+    retryableTendersDBDelegate.save(event);
+
+    var supplierSelection = event.getCapabilityAssessmentSuppliers().stream()
+        .filter(s -> s.getOrganisationMapping().getId().equals(supplierOrgMapping.getId()))
+        .findFirst().orElseThrow();
+
+    retryableTendersDBDelegate.delete(supplierSelection);
+  }
+
+  /**
+   * Delete supplier from Jaggaer.
+   *
+   * @param event
+   */
+  private void deleteSupplierFromJaggaer(final ProcurementEvent event,
+      final OrganisationMapping supplierOrgMapping) {
+
+    // Get all current suppliers on Rfx and remove the one we want to delete
+    var existingRfx = jaggaerService.getRfx(event.getExternalEventId());
+    List<Supplier> updatedSuppliersList = existingRfx.getSuppliersList().getSupplier().stream()
+        .filter(
+            s -> !s.getCompanyData().getId().equals(supplierOrgMapping.getExternalOrganisationId()))
+        .collect(Collectors.toList());
+    var suppliersList = SuppliersList.builder().supplier(updatedSuppliersList).build();
+
+    // Build Rfx and update
+    var rfxSetting = RfxSetting.builder().rfxId(event.getExternalEventId())
+        .rfxReferenceCode(event.getExternalReferenceId()).build();
+    var rfx = Rfx.builder().rfxSetting(rfxSetting).suppliersList(suppliersList).build();
+    jaggaerService.createUpdateRfx(rfx, OperationCode.UPDATE_RESET);
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,7 @@ config:
         # ProjectName-EventType e.g. RM1234-Lot1a-CCS-RFP
         defaultTitleFormat: "%s-%s"
         endpoint: /esop/jint/api/public/ja/v1/rfxs/
-        templateId: itt_445
+        templateId: itt_9899
       getBuyerCompanyProfile:
         # endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==GURU;SUBUSERLOGIN=={{PRINCIPAL}}
         endpoint: /esop/jint/api/public/ja/v1/companyprofiles?comp=USER;SSO_CODE&flt=TYPE==BUYER;BRAVOID==${config.external.jaggaer.self-service-id}

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
@@ -234,13 +234,15 @@ class EventsControllerTest {
 
     var org = new OrganizationReference();
     org.setId(SUPPLIER_ID);
-    when(procurementEventService.addSupplier(PROC_PROJECT_ID, EVENT_ID, org)).thenReturn(org);
+    when(procurementEventService.addSuppliers(PROC_PROJECT_ID, EVENT_ID, List.of(org), false,
+        PRINCIPAL)).thenReturn(List.of(org));
 
     mockMvc
         .perform(post(EVENTS_PATH + "/{eventID}/suppliers", PROC_PROJECT_ID, EVENT_ID)
             .with(validJwtReqPostProcessor).contentType(APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(org)))
-        .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.id").value(SUPPLIER_ID));
+            .content(objectMapper.writeValueAsString(List.of(org))))
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(SUPPLIER_ID));
   }
 
   @Test
@@ -251,8 +253,8 @@ class EventsControllerTest {
             SUPPLIER_ID).with(validJwtReqPostProcessor).contentType(APPLICATION_JSON))
         .andDo(print()).andExpect(status().isOk()).andExpect(content().string("OK"));
 
-    verify(procurementEventService, times(1)).deleteSupplier(PROC_PROJECT_ID, EVENT_ID,
-        SUPPLIER_ID);
+    verify(procurementEventService, times(1)).deleteSupplier(PROC_PROJECT_ID, EVENT_ID, SUPPLIER_ID,
+        PRINCIPAL);
 
   }
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -6,10 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
@@ -115,6 +112,9 @@ class ProcurementEventServiceTest {
   private AssessmentService assessmentService;
 
   @MockBean
+  private ConclaveService conclaveService;
+
+  @MockBean
   private JourneyRepo journeyRepo;
 
   @MockBean
@@ -146,6 +146,9 @@ class ProcurementEventServiceTest {
 
   @MockBean
   private ProjectUserMappingRepo projectUserMappingRepo;
+
+  @MockBean
+  private SupplierSelectionRepo supplierSelectionRepo;
 
   private final CreateEvent createEvent = new CreateEvent();
 
@@ -625,10 +628,11 @@ class ProcurementEventServiceTest {
   }
 
   @Test
-  void testGetSuppliers() throws Exception {
+  void testGetSuppliersFromJaggaer() throws Exception {
 
     var event = new ProcurementEvent();
     event.setExternalEventId(RFX_ID);
+    event.setEventType(UPDATED_EVENT_TYPE);
 
     var companyData = CompanyData.builder().id(JAGGAER_SUPPLIER_ID).build();
     var supplier = Supplier.builder().companyData(companyData).build();
@@ -656,13 +660,14 @@ class ProcurementEventServiceTest {
   }
 
   @Test
-  void testAddSupplier() throws Exception {
+  void testAddSuppliersToJaggaer() throws Exception {
 
     var org = new OrganizationReference();
     org.setId(SUPPLIER_ID);
 
     var event = new ProcurementEvent();
     event.setExternalEventId(RFX_ID);
+    event.setEventType(UPDATED_EVENT_TYPE);
 
     var mapping = new OrganisationMapping();
     mapping.setExternalOrganisationId(JAGGAER_SUPPLIER_ID);
@@ -671,12 +676,13 @@ class ProcurementEventServiceTest {
     // Mock behaviours
     when(validationService.validateProjectAndEventIds(PROC_PROJECT_ID, PROC_EVENT_ID))
         .thenReturn(event);
-    when(organisationMappingRepo.findByOrganisationId(SUPPLIER_ID))
-        .thenReturn(Optional.of(mapping));
+    when(organisationMappingRepo.findByOrganisationIdIn(Set.of(SUPPLIER_ID)))
+        .thenReturn(Set.of(mapping));
 
     ArgumentCaptor<Rfx> rfxCaptor = ArgumentCaptor.forClass(Rfx.class);
 
-    var response = procurementEventService.addSupplier(PROC_PROJECT_ID, PROC_EVENT_ID, org);
+    var response = procurementEventService.addSuppliers(PROC_PROJECT_ID, PROC_EVENT_ID,
+        List.of(org), false, PRINCIPAL);
 
     // Verify
     verify(jaggaerService).createUpdateRfx(rfxCaptor.capture(), eq(OperationCode.CREATEUPDATE));
@@ -684,14 +690,15 @@ class ProcurementEventServiceTest {
     assertEquals(JAGGAER_SUPPLIER_ID,
         rfxCaptor.getValue().getSuppliersList().getSupplier().get(0).getCompanyData().getId());
 
-    assertEquals(SUPPLIER_ID, response.getId());
+    assertEquals(SUPPLIER_ID, response.stream().findFirst().get().getId());
   }
 
   @Test
-  void testDeleteSupplier() throws Exception {
+  void testDeleteSupplierFromJaggaer() throws Exception {
 
     var event = new ProcurementEvent();
     event.setExternalEventId(RFX_ID);
+    event.setEventType(UPDATED_EVENT_TYPE);
 
     var mapping = new OrganisationMapping();
     mapping.setExternalOrganisationId(JAGGAER_SUPPLIER_ID);
@@ -712,7 +719,7 @@ class ProcurementEventServiceTest {
 
     ArgumentCaptor<Rfx> rfxCaptor = ArgumentCaptor.forClass(Rfx.class);
 
-    procurementEventService.deleteSupplier(PROC_PROJECT_ID, PROC_EVENT_ID, SUPPLIER_ID);
+    procurementEventService.deleteSupplier(PROC_PROJECT_ID, PROC_EVENT_ID, SUPPLIER_ID, PRINCIPAL);
 
     // Verify (supplier removed from Rfx for reset update)
     verify(jaggaerService).createUpdateRfx(rfxCaptor.capture(), eq(OperationCode.UPDATE_RESET));

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/RetryableTendersDBDelegateTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/RetryableTendersDBDelegateTest.java
@@ -69,6 +69,9 @@ class RetryableTendersDBDelegateTest {
   @MockBean
   private ProjectUserMappingRepo projectUserMappingRepo;
 
+  @MockBean
+  private SupplierSelectionRepo supplierSelectionRepo;
+
   @Autowired
   private RetryableTendersDBDelegate retryableTendersDBDelegate;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-3509 - CA Suppliers

### Change description ###

- Changes the base ITT Template
- Updates Add/Get/Delete Suppliers - now if an event is of type FCA/DAA - suppliers are persisted in Tenders DB (logic to be written on transitioning event type to copy/overwrite suppliers list - different ticket)
- TODO in there - requires Conclave to be fixed to accept DUNS lookup

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
