### PR TITLE
Calculate score to 2 dp and adjust to number output types

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentCalculationService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentCalculationService.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
@@ -69,8 +69,7 @@ public class AssessmentCalculationService {
 
       var requirementScore = new RequirementScore().requirement(calcBase.getRequirementName())
           .criterion(calcBase.getSubmissionTypeName())
-          .value(Integer.valueOf(calcBase.getSubmissionValue()))
-          .weightedValue((int) Math.round(score));
+          .value(Integer.valueOf(calcBase.getSubmissionValue())).weightedValue(score);
       dimensionScores.addRequirementScoresItem(requirementScore);
 
       if (!dimensionScoresExists) {
@@ -93,22 +92,22 @@ public class AssessmentCalculationService {
           .flatMap(adw -> adw.getAssessmentToolSubmissionTypes().stream()).anyMatch(
               atst -> SUBMISSION_TYPE_SUBCONTRACTOR.equals(atst.getSubmissionType().getName()));
 
-      var supplierDimensionTotalScore = new AtomicInteger(0);
-      var subcontractorDimensionTotalScore = new AtomicInteger(0);
+      var supplierDimensionTotalScore = new AtomicReference<>(0d);
+      var subcontractorDimensionTotalScore = new AtomicReference<>(0d);
 
       supplierScore.getDimensionScores().forEach(dimension -> {
-        supplierDimensionTotalScore.addAndGet(dimension.getRequirementScores().stream()
+        supplierDimensionTotalScore.accumulateAndGet(dimension.getRequirementScores().stream()
             .filter(rs -> SUBMISSION_TYPE_SUPPLIER.equals(rs.getCriterion()))
-            .map(RequirementScore::getWeightedValue).reduce(0, Integer::sum));
+            .map(RequirementScore::getWeightedValue).reduce(0d, Double::sum), Double::sum);
 
-        subcontractorDimensionTotalScore.addAndGet(dimension.getRequirementScores().stream()
+        subcontractorDimensionTotalScore.accumulateAndGet(dimension.getRequirementScores().stream()
             .filter(rs -> SUBMISSION_TYPE_SUBCONTRACTOR.equals(rs.getCriterion()))
-            .map(RequirementScore::getWeightedValue).reduce(0, Integer::sum));
+            .map(RequirementScore::getWeightedValue).reduce(0d, Double::sum), Double::sum);
       });
 
-      var supplierTotal = subcontractorsAccepted
+      var supplierTotal = roundDouble(subcontractorsAccepted
           ? (supplierDimensionTotalScore.get() + subcontractorDimensionTotalScore.get()) / 2
-          : supplierDimensionTotalScore.get();
+          : supplierDimensionTotalScore.get(), 2);
 
       supplierScore.setTotal(supplierTotal);
 
@@ -163,6 +162,11 @@ public class AssessmentCalculationService {
 
     return assessmentCalculationBase.stream()
         .filter(cb -> retainSuppliers.contains(cb.getSupplierId())).collect(Collectors.toSet());
+  }
+
+  static double roundDouble(final double value, final int scale) {
+    var multiplier = Math.pow(10, scale); // 1 = 10, 2 = 100 etc
+    return Math.round(value * multiplier) / multiplier;
   }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-3396 & SCAT-3534

### Change description ###
As per ACs, adjust weighted requirement scores and total scores to retain accuracy (via double).  Round the total score to two decimal places.
Note: currently, the weighted scores are not rounded for output as they are used as-is for the overall calculation.  Need to clarify with BA whether they should be also be rounded for output or left with full scale.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
