### PR TITLE
SCAT-4249 - fix for getting events when only in Tenders DB (e.g. FCA)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<inputSpec>https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-scale-api-definitions/bugfix/SCAT-4249_assessment_status/capabilities/capability-service.yaml</inputSpec>
+							<inputSpec>https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-scale-api-definitions/master/capabilities/capability-service.yaml</inputSpec>
 							<generatorName>spring</generatorName>
 							<generateModels>true</generateModels>
 							<generateSupportingFiles>false</generateSupportingFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<inputSpec>https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-scale-api-definitions/master/capabilities/capability-service.yaml</inputSpec>
+							<inputSpec>https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-scale-api-definitions/bugfix/SCAT-4249_assessment_status/capabilities/capability-service.yaml</inputSpec>
 							<generatorName>spring</generatorName>
 							<generateModels>true</generateModels>
 							<generateSupportingFiles>false</generateSupportingFiles>

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
@@ -38,7 +38,7 @@ public class EventsController extends AbstractRestController {
     var principal = getPrincipalFromJwt(authentication);
     log.info("getEventsForProject invoked on behalf of principal: {}", principal);
 
-    return procurementEventService.getEventsForProject(procId);
+    return procurementEventService.getEventsForProject(procId, principal);
   }
 
   @PostMapping

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ca/AssessmentEntity.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ca/AssessmentEntity.java
@@ -28,7 +28,7 @@ public class AssessmentEntity {
 
   @Column(name = "status")
   @Enumerated(EnumType.STRING)
-  private AssessmentStatus status;
+  private AssessmentStatusEntity status;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "assessment_tool_id")

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ca/AssessmentStatusEntity.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ca/AssessmentStatusEntity.java
@@ -1,6 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.entity.ca;
 
-public enum AssessmentStatus {
+public enum AssessmentStatusEntity {
 
-  ACTIVE, COMPLETED
+  ACTIVE, COMPLETE
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentService.java
@@ -424,11 +424,6 @@ public class AssessmentService {
           dimensionRequirement.getName(), dimensionId, dimension.getName()));
     }
 
-    // var requirementMap = new HashMap<Requirement, List<Requirement>>();
-    // dimensionRequirement.getRequirements().stream().forEach(r -> {
-    // var requirementsInGroup = requirementMap.get(r.get)
-    // });
-
     return dimension;
   }
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentService.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.cat.exception.AuthorisationFailureException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.*;
-import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.AssessmentSummary.StatusEnum;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ca.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.DefineEventType;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
@@ -107,7 +106,8 @@ public class AssessmentService {
         .orElseThrow(() -> new ValidationException(
             format(ERR_FMT_EVENT_TYPE_INVALID_FOR_CA_LOT, eventType, caNumber, lotNumber)));
 
-    var assessment = new Assessment().externalToolId(lotEventType.getAssessmentToolId());
+    var assessment = new Assessment().externalToolId(lotEventType.getAssessmentToolId())
+        .status(AssessmentStatus.ACTIVE);
     log.debug("Empty assessment created with ext tool-id [{}] for event type [{}]",
         lotEventType.getAssessmentToolId(), eventType);
     return createAssessment(assessment, principal);
@@ -138,7 +138,7 @@ public class AssessmentService {
     // Create an AssessmentEntity
     var entity = new AssessmentEntity();
     entity.setTool(tool);
-    entity.setStatus(AssessmentStatus.ACTIVE);
+    entity.setStatus(AssessmentStatusEntity.ACTIVE);
     entity.setBuyerOrganisationId(conclaveUser.getOrganisationId());
     entity.setTimestamps(createTimestamps(principal));
 
@@ -193,7 +193,7 @@ public class AssessmentService {
       var summary = new AssessmentSummary();
       summary.setAssessmentId(a.getId());
       summary.setExternalToolId(a.getTool().getExternalToolId());
-      summary.setStatus(StatusEnum.fromValue(a.getStatus().toString().toLowerCase()));
+      summary.setStatus(AssessmentStatus.fromValue(a.getStatus().toString().toLowerCase()));
       return summary;
     }).collect(Collectors.toList());
   }
@@ -270,6 +270,7 @@ public class AssessmentService {
     response.setAssessmentId(assessmentId);
     response.setDimensionRequirements(dimensions);
     response.setScores(scores);
+    response.setStatus(AssessmentStatus.fromValue(assessment.getStatus().toString().toLowerCase()));
 
     return response;
   }
@@ -423,6 +424,11 @@ public class AssessmentService {
       throw new ValidationException(format(ERR_MSG_FMT_DIMENSION_ID_NOT_MATCH_NAME,
           dimensionRequirement.getName(), dimensionId, dimension.getName()));
     }
+
+    // var requirementMap = new HashMap<Requirement, List<Requirement>>();
+    // dimensionRequirement.getRequirements().stream().forEach(r -> {
+    // var requirementsInGroup = requirementMap.get(r.get)
+    // });
 
     return dimension;
   }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/AssessmentService.java
@@ -106,8 +106,7 @@ public class AssessmentService {
         .orElseThrow(() -> new ValidationException(
             format(ERR_FMT_EVENT_TYPE_INVALID_FOR_CA_LOT, eventType, caNumber, lotNumber)));
 
-    var assessment = new Assessment().externalToolId(lotEventType.getAssessmentToolId())
-        .status(AssessmentStatus.ACTIVE);
+    var assessment = new Assessment().externalToolId(lotEventType.getAssessmentToolId());
     log.debug("Empty assessment created with ext tool-id [{}] for event type [{}]",
         lotEventType.getAssessmentToolId(), eventType);
     return createAssessment(assessment, principal);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -584,19 +584,26 @@ public class ProcurementEventService {
    * @param projectId
    * @return
    */
-  public List<EventSummary> getEventsForProject(final Integer projectId) {
+  public List<EventSummary> getEventsForProject(final Integer projectId, final String principal) {
 
     var events = retryableTendersDBDelegate.findProcurementEventsByProjectId(projectId);
 
     return events.stream().map(event -> {
 
-      var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());
+      TenderStatus statusCode;
+
+      if (event.getExternalEventId() == null) {
+        var assessment = assessmentService.getAssessment(event.getAssessmentId(), principal);
+        statusCode = TenderStatus.fromValue(assessment.getStatus().toString().toLowerCase());
+      } else {
+        var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());
+        statusCode = jaggaerAPIConfig.getRfxStatusToTenderStatus()
+            .get(exportRfxResponse.getRfxSetting().getStatusCode());
+      }
 
       return tendersAPIModelUtils.buildEventSummary(event.getEventID(), event.getEventName(),
           Optional.ofNullable(event.getExternalEventId()),
-          ViewEventType.fromValue(event.getEventType()), jaggaerAPIConfig
-              .getRfxStatusToTenderStatus().get(exportRfxResponse.getRfxSetting().getStatusCode()),
-          EVENT_STAGE, Optional.empty());
+          ViewEventType.fromValue(event.getEventType()), statusCode, EVENT_STAGE, Optional.empty());
     }).collect(Collectors.toList());
   }
 

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsControllerTest.java
@@ -327,6 +327,6 @@ class EventsControllerTest {
         .andDo(print()).andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON));
 
-    verify(procurementEventService, times(1)).getEventsForProject(PROC_PROJECT_ID);
+    verify(procurementEventService, times(1)).getEventsForProject(PROC_PROJECT_ID, PRINCIPAL);
   }
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -855,7 +855,7 @@ class ProcurementEventServiceTest {
     when(procurementEventRepo.findByProjectId(PROC_PROJECT_ID)).thenReturn(events);
     when(jaggaerService.getRfx(RFX_ID)).thenReturn(rfxResponse);
 
-    var response = procurementEventService.getEventsForProject(PROC_PROJECT_ID);
+    var response = procurementEventService.getEventsForProject(PROC_PROJECT_ID, PRINCIPAL);
 
     // Verify
     assertEquals(1, response.size());


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-4249 - bugfix - get events for project endpoint was throwing error when an FCA event was present as it was trying to retrieve details from Jaggaer (no event exists in Jaggaer for FCA events).


### Change description ###



### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
