### PR TITLE
Fix assessSupplierTarget val check for DAA

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationService.java
@@ -2,6 +2,7 @@ package uk.gov.crowncommercial.dts.scale.cat.service;
 
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Set;
 import javax.validation.ValidationException;
 import org.springframework.stereotype.Service;
@@ -105,6 +106,7 @@ public class ValidationService {
             "assessmentId is invalid for eventType: " + updateEvent.getEventType());
       }
 
+      // Verify the assessment with that ID already exists
       assessmentService.getAssessment(updateEvent.getAssessmentId(), principal);
     }
 
@@ -126,7 +128,8 @@ public class ValidationService {
       }
 
       // SCAT-3504 AC4
-      if (DefineEventType.DAA == updateEvent.getEventType() && assessmentSupplierTarget > 1) {
+      if (Objects.equals(DefineEventType.DAA.name(), existingEvent.getEventType())
+          && assessmentSupplierTarget > 1) {
         throw new ValidationException("assessmentSupplierTarget must be 1 for event type DAA");
       }
     }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationServiceTest.java
@@ -178,9 +178,7 @@ class ValidationServiceTest {
 
   @Test
   void testValidateUpdateEventAssessment_assSupTgtInvalidForDAA() {
-    var updateEvent = new UpdateEvent().assessmentId(1).assessmentSupplierTarget(10)
-        .eventType(DefineEventType.DAA);
-
+    var updateEvent = new UpdateEvent().assessmentId(1).assessmentSupplierTarget(10);
     var procurementEvent = ProcurementEvent.builder().eventType("DAA").build();
 
     var ex = assertThrows(ValidationException.class, () -> validationService


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/SCAT-3816


### Change description ###
Fix the check on `assessmentSupplierTarget` value for `DAA` events to reference the _existing_ assessment event type, not the update event type (which will have already been used and cannot be re-used). 


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
