### PR TITLE
SCAT-4484 - temporary fix for /projects performance issue (limit 5)

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/Constants.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/Constants.java
@@ -32,4 +32,8 @@ public class Constants {
 
   public static final Set<DefineEventType> ASSESSMENT_EVENT_TYPES =
       Set.of(DefineEventType.FC, DefineEventType.FCA, DefineEventType.DAA);
+
+  public static final Set<DefineEventType> TENDER_DB_ONLY_EVENT_TYPES =
+      Set.of(DefineEventType.FCA, DefineEventType.DAA);
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementEvent.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementEvent.java
@@ -1,6 +1,7 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.entity;
 
 import static uk.gov.crowncommercial.dts.scale.cat.config.Constants.ASSESSMENT_EVENT_TYPES;
+import static uk.gov.crowncommercial.dts.scale.cat.config.Constants.TENDER_DB_ONLY_EVENT_TYPES;
 import java.time.Instant;
 import java.util.Set;
 import javax.persistence.*;
@@ -91,13 +92,24 @@ public class ProcurementEvent {
   }
 
   /**
-   * Is the event an Assessment Event (e.g. FCA, DAA)?
+   * Is the event an Assessment Event (e.g. FC, FCA, DAA)?
    *
    * @param event
    * @return true if it is, false otherwise
    */
   public boolean isAssessment() {
     return ASSESSMENT_EVENT_TYPES.stream().map(DefineEventType::name)
+        .anyMatch(aet -> aet.equals(getEventType()));
+  }
+
+  /**
+   * Is the event only persisted in Tenders DB (e.g. FCA, DAA)?
+   *
+   * @param event
+   * @return true if it is, false otherwise
+   */
+  public boolean isTendersDBOnly() {
+    return TENDER_DB_ONLY_EVENT_TYPES.stream().map(DefineEventType::name)
         .anyMatch(aet -> aet.equals(getEventType()));
   }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/ProjectUserMappingRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/ProjectUserMappingRepo.java
@@ -1,10 +1,11 @@
 package uk.gov.crowncommercial.dts.scale.cat.repo;
 
+import java.util.List;
+import java.util.Set;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProjectUserMapping;
-
-import java.util.Set;
 
 /**
  *
@@ -15,4 +16,6 @@ public interface ProjectUserMappingRepo extends JpaRepository<ProjectUserMapping
   Set<ProjectUserMapping> findByProjectId(Integer projectId);
 
   Set<ProjectUserMapping> findByUserId(String userId);
+
+  List<ProjectUserMapping> findByUserId(String userId, Pageable pageable);
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
@@ -3,6 +3,7 @@ package uk.gov.crowncommercial.dts.scale.cat.repo;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.stereotype.Service;
@@ -230,6 +231,12 @@ public class RetryableTendersDBDelegate {
   @TendersDBRetryable
   public Set<ProjectUserMapping> findProjectUserMappingByUserId(final String userId) {
     return projectUserMappingRepo.findByUserId(userId);
+  }
+
+  @TendersDBRetryable
+  public List<ProjectUserMapping> findProjectUserMappingByUserId(final String userId,
+      final Pageable pageable) {
+    return projectUserMappingRepo.findByUserId(userId, pageable);
   }
 
   @TendersDBRetryable

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -344,13 +344,12 @@ public class ProcurementEventService {
 
     var event = validationService.validateProjectAndEventIds(procId, eventId);
 
-    if (event.isAssessment()) {
-      log.debug("Event {} is an Assessment Type {}, retrieve suppliers from Tenders DB",
-          event.getId(), event.getEventType());
+    if (event.isTendersDBOnly()) {
+      log.debug("Event {} is retrieved from Tenders DB only {}", event.getId(),
+          event.getEventType());
       return getSuppliersFromTendersDB(event);
     }
-    log.debug("Event {} is not an Assessment Type {}, retrieve suppliers from Jaggaer",
-        event.getId(), event.getEventType());
+    log.debug("Event {} is retrieved from Jaggaer {}", event.getId(), event.getEventType());
     return getSuppliersFromJaggaer(event);
   }
 
@@ -398,16 +397,15 @@ public class ProcurementEventService {
     }
 
     /*
-     * If Event is an Assessment Type, suppliers are stored in the Tenders DB only, otherwise they
-     * are stored in Jaggaer.
+     * If Event is a Tenders DB only type, suppliers are stored in the Tenders DB only, otherwise
+     * they are stored in Jaggaer.
      */
-    if (event.isAssessment()) {
-      log.debug("Event {} is an Assessment Type {}, add suppliers to Tenders DB",
-          event.getEventID(), event.getEventType());
+    if (event.isTendersDBOnly()) {
+      log.debug("Event {} is persisted in Tenders DB only {}", event.getEventID(),
+          event.getEventType());
       addSuppliersToTendersDB(event, supplierOrgMappings, overwrite, principal);
     } else {
-      log.debug("Event {} is an not an Assessment Type {}, add suppliers to Jaggaer", event.getId(),
-          event.getEventType());
+      log.debug("Event {} is persisted in Jaggaer {}", event.getId(), event.getEventType());
       addSuppliersToJaggaer(event, supplierOrgMappings, overwrite);
     }
 
@@ -437,16 +435,14 @@ public class ProcurementEventService {
             String.format(SUPPLIER_NOT_FOUND_MSG, organisationId)));
 
     /*
-     * If Event is an Assessment Type, suppliers are stored in the Tenders DB only, otherwise they
-     * are stored in Jaggaer.
+     * If Event is a Tenders DB only type, suppliers are stored in the Tenders DB only, otherwise
+     * they are stored in Jaggaer.
      */
-    if (event.isAssessment()) {
-      log.debug("Event {} is an Assessment Type {}, delete supplier from Tenders DB", event.getId(),
-          event.getEventType());
+    if (event.isTendersDBOnly()) {
+      log.debug("Event {} is persisted in Tenders DB only {}", event.getId(), event.getEventType());
       deleteSupplierFromTendersDB(event, om, principal);
     } else {
-      log.debug("Event {} is an Assessment Type {}, delete supplier from Jaggaer", event.getId(),
-          event.getEventType());
+      log.debug("Event {} is persisted in Jaggaer {}", event.getId(), event.getEventType());
       deleteSupplierFromJaggaer(event, om);
     }
   }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectService.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -349,7 +351,11 @@ public class ProcurementProjectService {
     var jaggaerUserId = userProfileService.resolveBuyerUserByEmail(principal)
         .orElseThrow(() -> new AuthorisationFailureException("Jaggaer user not found")).getUserId();
 
-    var projects = retryableTendersDBDelegate.findProjectUserMappingByUserId(jaggaerUserId);
+    // TODO - due to errors logging in for some users (SCAT-4484), hard-coding to limit the number
+    // of projects returned for now until a better solution is implemented (SCAT-4583)
+    // var projects = retryableTendersDBDelegate.findProjectUserMappingByUserId(jaggaerUserId);
+    var projects = retryableTendersDBDelegate.findProjectUserMappingByUserId(jaggaerUserId,
+        PageRequest.of(0, 5, Sort.by("timestamps.createdAt").descending()));
 
     if (!CollectionUtils.isEmpty(projects)) {
       return projects.stream().map(this::convertProjectToProjectPackageSummary)
@@ -392,23 +398,34 @@ public class ProcurementProjectService {
     projectPackageSummary.setProjectId(mapping.getProject().getId());
     projectPackageSummary.setProjectName(mapping.getProject().getProjectName());
 
-    log.debug("Get Rfx from Jaggaer: " + dbEvent.getExternalEventId());
-    var exportRfxResponse = jaggaerService.getRfx(dbEvent.getExternalEventId());
-    var status = findTenderStatus(dbEvent, exportRfxResponse);
-    var eventSummary = tendersAPIModelUtils.buildEventSummary(dbEvent.getEventID(),
-        dbEvent.getEventName(), Optional.ofNullable(dbEvent.getExternalReferenceId()),
-        ViewEventType.fromValue(dbEvent.getEventType()), status, ReleaseTag.TENDER,
-        Optional.ofNullable(dbEvent.getAssessmentId()));
-    eventSummary
-        .tenderPeriod(new Period1().startDate(exportRfxResponse.getRfxSetting().getPublishDate())
-            .endDate(exportRfxResponse.getRfxSetting().getCloseDate()));
+    EventSummary eventSummary;
+
+    if (dbEvent.isTendersDBOnly() || dbEvent.getExternalEventId() == null) {
+      log.debug("Get Event from Tenders DB: {}", dbEvent.getId());
+      eventSummary = tendersAPIModelUtils.buildEventSummary(dbEvent.getEventID(),
+          dbEvent.getEventName(), Optional.ofNullable(dbEvent.getExternalReferenceId()),
+          ViewEventType.fromValue(dbEvent.getEventType()), TenderStatus.PLANNING, ReleaseTag.TENDER,
+          Optional.ofNullable(dbEvent.getAssessmentId()));
+    } else {
+      log.debug("Get Rfx from Jaggaer: {}", dbEvent.getExternalEventId());
+      var exportRfxResponse = jaggaerService.getRfx(dbEvent.getExternalEventId());
+      var status = findTenderStatus(dbEvent, exportRfxResponse);
+      eventSummary = tendersAPIModelUtils.buildEventSummary(dbEvent.getEventID(),
+          dbEvent.getEventName(), Optional.ofNullable(dbEvent.getExternalReferenceId()),
+          ViewEventType.fromValue(dbEvent.getEventType()), status, ReleaseTag.TENDER,
+          Optional.ofNullable(dbEvent.getAssessmentId()));
+      eventSummary
+          .tenderPeriod(new Period1().startDate(exportRfxResponse.getRfxSetting().getPublishDate())
+              .endDate(exportRfxResponse.getRfxSetting().getCloseDate()));
+    }
+
     projectPackageSummary.activeEvent(eventSummary);
     return Optional.of(projectPackageSummary);
-
   }
 
   private TenderStatus findTenderStatus(final ProcurementEvent dbEvent,
       final ExportRfxResponse exportRfxResponse) {
+
     var statusCode = exportRfxResponse.getRfxSetting().getStatusCode();
     String eventType = dbEvent.getEventType();
     // This logic is based on attached excel of SCAT-3671


### PR DESCRIPTION
### JIRA link (if applicable) ###

SCAT-4484

### Change description ###

For some users the amount of time it takes to retrieve all their projects for dashboard causes the page to fail to load, which looks like login has failed. 

This is a temporary fix to unblock until better solution is implemented. The paging solution here could be extended to resolve that issue potentially - if paging could be implemented in client.

This also adds in a fix for another issue spotted - to prevent a call being made to Jaggaer for event types that are only stored in the Tenders DB (FCA, DAA). Had to distinguish between these and assessment event event types - as not a direct 1:1 correlation now FC has been added to the assessment types.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
