### PR TITLE
Feature/scat 4121 doc upload service integration

### DIFF
--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -16,6 +16,11 @@ data "cloudfoundry_service_instance" "tenders_database" {
   space      = data.cloudfoundry_space.space.id
 }
 
+data "cloudfoundry_service_instance" "tenders_s3_documents" {
+  name_or_id = "${var.environment}-ccs-scale-cat-tenders-s3-documents"
+  space      = data.cloudfoundry_space.space.id
+}
+
 data "cloudfoundry_user_provided_service" "logit" {
   name  = "${var.environment}-ccs-scale-cat-logit-ssl-drain"
   space = data.cloudfoundry_space.space.id
@@ -27,6 +32,8 @@ data "cloudfoundry_user_provided_service" "ip_router" {
 }
 
 # SSM Params
+
+# Jaggaer
 data "aws_ssm_parameter" "jaggaer_client_id" {
   name = "/cat/${var.environment}/jaggaer-client-id"
 }
@@ -47,12 +54,9 @@ data "aws_ssm_parameter" "jaggaer_self_service_id" {
   name = "/cat/${var.environment}/jaggaer-self-service-id"
 }
 
+# Auth server / CII
 data "aws_ssm_parameter" "auth_server_jwk_set_uri" {
   name = "/cat/${var.environment}/auth-server-jwk-set-uri"
-}
-
-data "aws_ssm_parameter" "agreements_service_base_url" {
-  name = "/cat/${var.environment}/agreements-service-base-url"
 }
 
 data "aws_ssm_parameter" "conclave_wrapper_api_base_url" {
@@ -63,7 +67,12 @@ data "aws_ssm_parameter" "conclave_wrapper_api_key" {
   name = "/cat/${var.environment}/conclave-wrapper-api-key"
 }
 
-# RPA related params
+# Agreements Service
+data "aws_ssm_parameter" "agreements_service_base_url" {
+  name = "/cat/${var.environment}/agreements-service-base-url"
+}
+
+# RPA
 data "aws_ssm_parameter" "jaggaer_rpa_base_url" {
   name = "/cat/${var.environment}/jaggaer-rpa-base-url"
 }
@@ -89,6 +98,27 @@ data "aws_ssm_parameter" "jaggaer_rpa_buyer_password_temp" {
   name = "/cat/${var.environment}/jaggaer-rpa-buyer-password-temp"
 }
 
+# Document Upload Service
+data "aws_ssm_parameter" "document_upload_service_base_url" {
+  name = "/cat/${var.environment}/document-upload-service-base-url"
+}
+
+data "aws_ssm_parameter" "document_upload_service_api_key" {
+  name = "/cat/${var.environment}/document-upload-service-api-key"
+}
+
+data "aws_ssm_parameter" "document_upload_service_aws_access_key_id" {
+  name = "/cat/${var.environment}/document-upload-service-aws-access-key-id"
+}
+
+data "aws_ssm_parameter" "document_upload_service_aws_secret_key" {
+  name = "/cat/${var.environment}/document-upload-service-aws-secret-key"
+}
+
+data "aws_ssm_parameter" "document_upload_service_s3_bucket" {
+  name = "/cat/${var.environment}/document-upload-service-s3-bucket"
+}
+
 resource "cloudfoundry_app" "cat_service" {
   annotations = {}
   buildpack   = var.buildpack
@@ -96,17 +126,23 @@ resource "cloudfoundry_app" "cat_service" {
   enable_ssh  = true
   environment = {
     JBP_CONFIG_OPEN_JDK_JRE : "{ \"jre\": { version: 11.+ } }"
+    "config.flags.devMode" : var.dev_mode
+    "logging.level.uk.gov.crowncommercial.dts.scale.cat" : var.log_level
+
+    # Jaggaer
     "spring.security.oauth2.client.registration.jaggaer.client-id" : data.aws_ssm_parameter.jaggaer_client_id.value
     "spring.security.oauth2.client.registration.jaggaer.client-secret" : data.aws_ssm_parameter.jaggaer_client_secret.value
     "spring.security.oauth2.client.provider.jaggaer.token-uri" : data.aws_ssm_parameter.jaggaer_token_url.value
     "config.external.jaggaer.baseUrl" : data.aws_ssm_parameter.jaggaer_base_url.value
     "config.external.jaggaer.self-service-id" : data.aws_ssm_parameter.jaggaer_self_service_id.value
+    
+    # Auth server / CII
     "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" : data.aws_ssm_parameter.auth_server_jwk_set_uri.value
-    "config.external.agreements-service.baseUrl" : data.aws_ssm_parameter.agreements_service_base_url.value
     "config.external.conclave-wrapper.baseUrl" : data.aws_ssm_parameter.conclave_wrapper_api_base_url.value
     "config.external.conclave-wrapper.apiKey" : data.aws_ssm_parameter.conclave_wrapper_api_key.value
-    "config.flags.devMode" : var.dev_mode
-    "logging.level.uk.gov.crowncommercial.dts.scale.cat" : var.log_level
+    
+    # Agreements Service
+    "config.external.agreements-service.baseUrl" : data.aws_ssm_parameter.agreements_service_base_url.value
 
     # RPA
     "config.external.jaggaer.rpa.baseUrl" : data.aws_ssm_parameter.jaggaer_rpa_base_url.value
@@ -117,6 +153,13 @@ resource "cloudfoundry_app" "cat_service" {
 
     # RPA-TEMP
     "config.external.jaggaer.rpa.buyer-pwd" : data.aws_ssm_parameter.jaggaer_rpa_buyer_password_temp.value
+
+    # Document Upload Service
+    "config.external.document-upload.base-url" : data.aws_ssm_parameter.document_upload_service_base_url.value
+    "config.external.document-upload.api-key" : data.aws_ssm_parameter.document_upload_service_api_key.value
+    "config.external.document-upload.aws-access-key-id" : data.aws_ssm_parameter.document_upload_service_aws_access_key_id.value
+    "config.external.document-upload.aws-secret-key" : data.aws_ssm_parameter.document_upload_service_aws_secret_key.value
+    "config.external.document-upload.s3-bucket" : data.aws_ssm_parameter.document_upload_service_s3_bucket.value
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"
@@ -133,6 +176,10 @@ resource "cloudfoundry_app" "cat_service" {
 
   service_binding {
     service_instance = data.cloudfoundry_service_instance.tenders_database.id
+  }
+
+  service_binding {
+    service_instance = data.cloudfoundry_service_instance.tenders_s3_documents.id
   }
 
   service_binding {

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
 		<simple-odf.version>0.9.0</simple-odf.version>
 		<jena-core.version>4.4.0</jena-core.version>
 		<commons-io.version>2.11.0</commons-io.version>
+		<aws-java-sdk-s3.version>1.12.177</aws-java-sdk-s3.version>
+		<tika-core.version>2.3.0</tika-core.version>
 	</properties>
 
 	<dependencies>
@@ -147,7 +149,19 @@
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
 		</dependency>
-
+		
+		<dependency>
+		    <groupId>com.amazonaws</groupId>
+		    <artifactId>aws-java-sdk-s3</artifactId>
+		    <version>${aws-java-sdk-s3.version}</version>
+		</dependency>
+		
+		<dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>${tika-core.version}</version>
+        </dependency>
+		
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/Application.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/Application.java
@@ -2,10 +2,12 @@ package uk.gov.crowncommercial.dts.scale.cat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import lombok.RequiredArgsConstructor;
 
 @SpringBootApplication
 @RequiredArgsConstructor
+@EnableScheduling
 public class Application {
 
   public static void main(final String[] args) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApplicationConfig.java
@@ -2,14 +2,24 @@ package uk.gov.crowncommercial.dts.scale.cat.config;
 
 import java.time.Clock;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.crowncommercial.dts.scale.cat.config.paas.VCAPServices;
 
 /**
  *
  */
 @Configuration
 public class ApplicationConfig {
+
+  @Autowired
+  private Environment environment;
+
+  @Autowired
+  private ObjectMapper objectMapper;
 
   @Bean
   public Clock utcClock() {
@@ -19,6 +29,12 @@ public class ApplicationConfig {
   @Bean
   public ModelMapper modelMapper() {
     return new ModelMapper();
+  }
+
+  @Bean
+  public VCAPServices vcapServices() throws Exception {
+    var envVCAPServices = environment.getProperty("VCAP_SERVICES");
+    return objectMapper.readValue(envVCAPServices, VCAPServices.class);
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadAPIConfig.java
@@ -1,0 +1,34 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import lombok.Data;
+
+/**
+ *
+ */
+@Configuration
+@ConfigurationProperties(prefix = "config.external.document-upload", ignoreUnknownFields = true)
+@Data
+public class DocumentUploadAPIConfig {
+
+  public static final String KEY_URI_TEMPLATE = "uriTemplate";
+
+  private String baseUrl;
+  private String apiKey;
+
+  // AWS-S3
+  private String awsRegion;
+  private String awsAccessKeyId;
+  private String awsSecretKey;
+  private String s3Bucket;
+
+  private Integer timeoutDuration;
+  private String documentStateProcessing;
+  private String documentStateSafe;
+  private String documentStateUnsafe;
+  private Map<String, String> postDocument;
+  private Map<String, String> getDocumentRecord;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadClientConfig.java
@@ -1,0 +1,40 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.JettyClientHttpConnector;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.web.reactive.function.client.WebClient;
+import lombok.RequiredArgsConstructor;
+
+/**
+ *
+ */
+@Configuration
+@RequiredArgsConstructor
+public class DocumentUploadClientConfig {
+
+  private final DocumentUploadAPIConfig documentUploadAPIConfig;
+
+  @Bean("documentUploadWebClient")
+  public WebClient webClient(final OAuth2AuthorizedClientManager authorizedClientManager) {
+
+    var sslContextFactory = new SslContextFactory.Client(true);
+
+    // SCAT-2463: https://webtide.com/openjdk-11-and-tls-1-3-issues/
+    sslContextFactory.setExcludeProtocols("TLSv1.3");
+
+    ClientHttpConnector jettyHttpClientConnector =
+        new JettyClientHttpConnector(new HttpClient(sslContextFactory));
+
+    return WebClient.builder().clientConnector(jettyHttpClientConnector)
+        .baseUrl(documentUploadAPIConfig.getBaseUrl()).defaultHeader(ACCEPT, APPLICATION_JSON_VALUE)
+        .defaultHeader("x-api-key", documentUploadAPIConfig.getApiKey()).build();
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadS3ClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadS3ClientConfig.java
@@ -1,0 +1,29 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+
+/**
+ *
+ */
+@Configuration
+@RequiredArgsConstructor
+public class DocumentUploadS3ClientConfig {
+
+  private final DocumentUploadAPIConfig documentUploadAPIConfig;
+
+  @Bean("documentUploadS3Client")
+  public AmazonS3 amazonS3() {
+    var awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+        documentUploadAPIConfig.getAwsAccessKeyId(), documentUploadAPIConfig.getAwsSecretKey()));
+
+    return AmazonS3ClientBuilder.standard().withRegion(documentUploadAPIConfig.getAwsRegion())
+        .withCredentials(awsCredentials).build();
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/TendersS3ClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/TendersS3ClientConfig.java
@@ -1,0 +1,39 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.cat.config.paas.AWSS3Service;
+import uk.gov.crowncommercial.dts.scale.cat.config.paas.VCAPServices;
+
+/**
+ *
+ */
+@Configuration
+@RequiredArgsConstructor
+public class TendersS3ClientConfig {
+
+  private final VCAPServices vcapServices;
+
+  @Bean
+  public AWSS3Service tendersS3Bucket() {
+    return vcapServices.getAwsS3Services().stream()
+        .filter(b -> "sbx2-ccs-scale-cat-tenders-s3-documents".equals(b.getName())).findFirst()
+        .orElseThrow();
+  }
+
+  @Bean("tendersS3Client")
+  public AmazonS3 amazonS3(final AWSS3Service awsS3Bucket) {
+    var bucketCredentials = awsS3Bucket.getCredentials();
+    var awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+        bucketCredentials.getAwsAccessKeyId(), bucketCredentials.getAwsSecretAccessKey()));
+
+    return AmazonS3ClientBuilder.standard().withRegion(bucketCredentials.getAwsRegion())
+        .withCredentials(awsCredentials).build();
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/AWSS3Credentials.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/AWSS3Credentials.java
@@ -1,0 +1,25 @@
+package uk.gov.crowncommercial.dts.scale.cat.config.paas;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class AWSS3Credentials {
+
+  @JsonProperty("aws_region")
+  String awsRegion;
+
+  @JsonProperty("bucket_name")
+  String bucketName;
+
+  @JsonProperty("aws_access_key_id")
+  String awsAccessKeyId;
+
+  @JsonProperty("aws_secret_access_key")
+  String awsSecretAccessKey;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/AWSS3Service.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/AWSS3Service.java
@@ -1,0 +1,16 @@
+package uk.gov.crowncommercial.dts.scale.cat.config.paas;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class AWSS3Service {
+
+  AWSS3Credentials credentials;
+
+  /* Service name - useful for filtering */
+  String name;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/VCAPServices.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/VCAPServices.java
@@ -1,0 +1,20 @@
+package uk.gov.crowncommercial.dts.scale.cat.config.paas;
+
+import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ *
+ */
+@Value
+@Builder
+@Jacksonized
+public class VCAPServices {
+
+  @JsonProperty("aws-s3-bucket")
+  Set<AWSS3Service> awsS3Services;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/EventsController.java
@@ -136,7 +136,7 @@ public class EventsController extends AbstractRestController {
     // passed in as string to allow for lower case
     var audienceType = DocumentAudienceType.valueOf(audience.toUpperCase());
     return procurementEventService.uploadDocument(procId, eventId, multipartFile, audienceType,
-        description);
+        description, principal);
   }
 
   @GetMapping(value = "/{eventID}/documents/{documentID}")
@@ -148,13 +148,27 @@ public class EventsController extends AbstractRestController {
     var principal = getPrincipalFromJwt(authentication);
     log.info("getDocument invoked on behalf of principal: {}", principal);
 
-    var document = procurementEventService.getDocument(procId, eventId, documentId);
+    var document = procurementEventService.getDocument(procId, eventId, documentId, principal);
     var documentKey = DocumentKey.fromString(documentId);
 
     return ResponseEntity.ok().contentType(document.getContentType())
         .header(HttpHeaders.CONTENT_DISPOSITION,
             "attachment; filename=\"" + documentKey.getFileName() + "\"")
         .body(document.getData());
+  }
+
+  @DeleteMapping(value = "/{eventID}/documents/{documentID}")
+  public StringValueResponse deleteDocument(@PathVariable("procID") final Integer procId,
+      @PathVariable("eventID") final String eventId,
+      @PathVariable("documentID") final String documentId,
+      final JwtAuthenticationToken authentication) {
+
+    var principal = getPrincipalFromJwt(authentication);
+    log.info("deleteDocument invoked on behalf of principal: {}", principal);
+
+    procurementEventService.deleteDocument(procId, eventId, documentId);
+
+    return new StringValueResponse("OK");
   }
 
   @PutMapping("/{eventID}/publish")

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/DocumentUploadApplicationException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/exception/DocumentUploadApplicationException.java
@@ -1,0 +1,24 @@
+package uk.gov.crowncommercial.dts.scale.cat.exception;
+
+import java.util.Optional;
+
+/**
+ * Encapsulate details of a Jaggaer application exception (a 200 OK response with error code and
+ * message, such as when an invalid project template code is provided in create project)
+ */
+public class DocumentUploadApplicationException extends UpstreamServiceException {
+
+  private static final String SERVICE_NAME = "Document Upload Service";
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  public DocumentUploadApplicationException(final Object code, final String message) {
+    super(SERVICE_NAME, Optional.of(code), message);
+  }
+
+  public DocumentUploadApplicationException(final String message) {
+    super(SERVICE_NAME, Optional.empty(), message);
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/documentupload/DocumentFile.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/documentupload/DocumentFile.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.documentupload;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ *
+ */
+@Value
+@Builder
+@Jacksonized
+public class DocumentFile {
+
+  String url;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/documentupload/DocumentStatus.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/documentupload/DocumentStatus.java
@@ -1,0 +1,26 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.documentupload;
+
+import java.time.ZonedDateTime;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Represents a document and its (virus check) state on the external Document Upload Service
+ */
+@Value
+@Builder
+@Jacksonized
+public class DocumentStatus {
+
+  String id;
+
+  @JsonProperty("createdAt")
+  ZonedDateTime createdAt;
+  String state;
+
+  @JsonProperty("documentFile")
+  DocumentFile documentFile;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/DocumentUpload.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/DocumentUpload.java
@@ -1,0 +1,55 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.entity;
+
+import javax.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.DocumentAudienceType;
+
+/**
+ *
+ */
+@Entity
+@Table(name = "document_uploads")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@EqualsAndHashCode(exclude = "procurementEvent")
+public class DocumentUpload {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "document_upload_id")
+  Integer id;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "event_id")
+  ProcurementEvent procurementEvent;
+
+  @Column(name = "document_id")
+  String documentId;
+
+  @Column(name = "external_document_id")
+  String externalDocumentId;
+
+  @Column(name = "external_status")
+  @Enumerated(EnumType.STRING)
+  VirusCheckStatus externalStatus;
+
+  @Column(name = "audience")
+  @Enumerated(EnumType.STRING)
+  DocumentAudienceType audience;
+
+  @Column(name = "document_description")
+  String documentDescription;
+
+  @Column(name = "size")
+  Long size;
+
+  @Column(name = "mimetype")
+  String mimetype;
+
+  @Embedded
+  private Timestamps timestamps;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementEvent.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/ProcurementEvent.java
@@ -87,6 +87,11 @@ public class ProcurementEvent {
   @Column(name = "procurement_template_payload", insertable = false, updatable = false)
   String procurementTemplatePayloadRaw;
 
+  @ToString.Exclude
+  @OneToMany(mappedBy = "procurementEvent", fetch = FetchType.LAZY, cascade = CascadeType.ALL,
+      orphanRemoval = true)
+  Set<DocumentUpload> documentUploads;
+
   public String getEventID() {
     return ocdsAuthorityName + "-" + ocidPrefix + "-" + id;
   }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/VirusCheckStatus.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/VirusCheckStatus.java
@@ -1,0 +1,19 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.entity;
+
+/**
+ * Virus check (document upload service) processing status
+ */
+public enum VirusCheckStatus {
+
+  PROCESSING, SAFE, UNSAFE;
+
+  public static VirusCheckStatus fromName(final String name) {
+    for (VirusCheckStatus b : VirusCheckStatus.values()) {
+      if (b.name().equalsIgnoreCase(name)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected name '" + name + "'");
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/DocumentUploadRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/DocumentUploadRepo.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.cat.repo;
+
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.DocumentUpload;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.VirusCheckStatus;
+
+/**
+ *
+ */
+@Repository
+public interface DocumentUploadRepo extends JpaRepository<DocumentUpload, Integer> {
+
+  Set<DocumentUpload> findByExternalStatus(VirusCheckStatus externalStatus);
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/DocGenService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/DocGenService.java
@@ -1,5 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.cat.service;
 
+import static uk.gov.crowncommercial.dts.scale.cat.model.generated.DocumentAudienceType.SUPPLIER;
 import java.io.ByteArrayOutputStream;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -34,7 +35,6 @@ import uk.gov.crowncommercial.dts.scale.cat.exception.UnhandledEdgeCaseException
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.Requirement.NonOCDS;
 import uk.gov.crowncommercial.dts.scale.cat.model.agreements.Requirement.Option;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.*;
-import uk.gov.crowncommercial.dts.scale.cat.model.generated.DocumentAudienceType;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
 import uk.gov.crowncommercial.dts.scale.cat.utils.ByteArrayMultipartFile;
 
@@ -95,14 +95,14 @@ public class DocGenService {
       final ByteArrayOutputStream documentOutputStream) {
     var fileName = String.format(PROFORMA_FILENAME_FMT, procurementEvent.getEventID(),
         procurementEvent.getEventType(), procurementEvent.getProject().getProjectName());
+    var fileDescription =
+        procurementEvent.getEventType() + " pro forma for tender: " + procurementEvent.getEventID();
 
     var multipartFile = new ByteArrayMultipartFile(documentOutputStream.toByteArray(), fileName,
         Constants.MEDIA_TYPE_ODT.toString());
 
-    procurementEventService.uploadDocument(procurementEvent.getProject().getId(),
-        procurementEvent.getEventID(), multipartFile, DocumentAudienceType.SUPPLIER,
-        procurementEvent.getEventType() + " pro forma for tender: "
-            + procurementEvent.getEventID());
+    procurementEventService.eventUploadDocument(procurementEvent, fileName, fileDescription,
+        SUPPLIER, multipartFile);
   }
 
   Object getDataReplacement(final ProcurementEvent event,

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -9,7 +9,9 @@ import static uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig.ENDPO
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.transaction.Transactional;
 import org.apache.commons.io.FilenameUtils;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,15 +27,14 @@ import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationExceptio
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
 import uk.gov.crowncommercial.dts.scale.cat.model.DocumentAttachment;
 import uk.gov.crowncommercial.dts.scale.cat.model.DocumentKey;
-import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
-import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
-import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementProject;
-import uk.gov.crowncommercial.dts.scale.cat.model.entity.SupplierSelection;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.Tender;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.*;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
 import uk.gov.crowncommercial.dts.scale.cat.service.ca.AssessmentService;
+import uk.gov.crowncommercial.dts.scale.cat.service.documentupload.DocumentUploadService;
+import uk.gov.crowncommercial.dts.scale.cat.utils.ByteArrayMultipartFile;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 
 /**
@@ -50,9 +51,11 @@ public class ProcurementEventService {
   private static final String ADDITIONAL_INFO_LOT_NUMBER = "Lot Number";
   private static final String ADDITIONAL_INFO_LOCALE = "en_GB";
   private static final ReleaseTag EVENT_STAGE = ReleaseTag.TENDER;
-  private static final String SUPPLIER_NOT_FOUND_MSG =
+  private static final String ERR_MSG_FMT_SUPPLIER_NOT_FOUND =
       "Organisation id '%s' not found in organisation mappings";
-  public static final String JAGGAER_USER_NOT_FOUND = "Jaggaer user not found";
+  public static final String ERR_MSG_JAGGAER_USER_NOT_FOUND = "Jaggaer user not found";
+  public static final String ERR_MSG_FMT_DOCUMENT_NOT_FOUND =
+      "Document upload record for ID [%s] not found";
 
   private final UserProfileService userProfileService;
   private final CriteriaService criteriaService;
@@ -64,6 +67,7 @@ public class ProcurementEventService {
   private final SupplierService supplierService;
   private final DocumentConfig documentConfig;
   private final AssessmentService assessmentService;
+  private final DocumentUploadService documentUploadService;
 
   // TODO: switch remaining direct Jaggaer calls to use jaggaerService
   private final JaggaerAPIConfig jaggaerAPIConfig;
@@ -181,7 +185,8 @@ public class ProcurementEventService {
 
     // Fetch Jaggaer ID and Buyer company ID from Jaggaer profile based on OIDC login id
     var jaggaerUserId = userProfileService.resolveBuyerUserByEmail(principal)
-        .orElseThrow(() -> new AuthorisationFailureException(JAGGAER_USER_NOT_FOUND)).getUserId();
+        .orElseThrow(() -> new AuthorisationFailureException(ERR_MSG_JAGGAER_USER_NOT_FOUND))
+        .getUserId();
     var jaggaerBuyerCompanyId =
         userProfileService.resolveBuyerCompanyByEmail(principal).getBravoId();
 
@@ -432,7 +437,7 @@ public class ProcurementEventService {
     // Determine Jaggaer supplier id
     var om = retryableTendersDBDelegate.findOrganisationMappingByOrganisationId(organisationId)
         .orElseThrow(() -> new IllegalArgumentException(
-            String.format(SUPPLIER_NOT_FOUND_MSG, organisationId)));
+            String.format(ERR_MSG_FMT_SUPPLIER_NOT_FOUND, organisationId)));
 
     /*
      * If Event is a Tenders DB only type, suppliers are stored in the Tenders DB only, otherwise
@@ -459,30 +464,14 @@ public class ProcurementEventService {
    * @param eventId
    * @return
    */
+  @Transactional
   public Collection<DocumentSummary> getDocumentSummaries(final Integer procId,
       final String eventId) {
 
     var event = validationService.validateProjectAndEventIds(procId, eventId);
-    var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());
-    Collection<DocumentSummary> documents = new ArrayList<>();
 
-    if (exportRfxResponse.getBuyerAttachmentsList().getAttachment() == null) {
-      exportRfxResponse.setBuyerAttachmentsList(
-          BuyerAttachmentsList.builder().attachment(new ArrayList<>()).build());
-    }
-    exportRfxResponse.getBuyerAttachmentsList().getAttachment().stream()
-        .map(ba -> tendersAPIModelUtils.buildDocumentSummary(ba, DocumentAudienceType.BUYER))
-        .forEachOrdered(documents::add);
-
-    if (exportRfxResponse.getSellerAttachmentsList().getAttachment() == null) {
-      exportRfxResponse.setSellerAttachmentsList(
-          SellerAttachmentsList.builder().attachment(new ArrayList<>()).build());
-    }
-    exportRfxResponse.getSellerAttachmentsList().getAttachment().stream()
-        .map(ba -> tendersAPIModelUtils.buildDocumentSummary(ba, DocumentAudienceType.SUPPLIER))
-        .forEachOrdered(documents::add);
-
-    return documents;
+    return event.getDocumentUploads().stream().map(tendersAPIModelUtils::buildDocumentSummary)
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -493,11 +482,13 @@ public class ProcurementEventService {
    * @param multipartFile
    * @param audience
    * @param fileDescription
+   * @param principal
    * @return
    */
+  @Transactional
   public DocumentSummary uploadDocument(final Integer procId, final String eventId,
       final MultipartFile multipartFile, final DocumentAudienceType audience,
-      final String fileDescription) {
+      final String fileDescription, final String principal) {
 
     log.debug("Upload Document to event {}", eventId);
 
@@ -516,19 +507,119 @@ public class ProcurementEventService {
           + " bytes. Maximum allowed upload size is: " + documentConfig.getMaxSize() + " bytes");
     }
 
+    var event = validationService.validateProjectAndEventIds(procId, eventId);
+
     // Validate total file size
-    var currentDocuments = getDocumentSummaries(procId, eventId);
     var totalEventFileSize =
-        currentDocuments.stream().map(DocumentSummary::getFileSize).reduce(0L, Long::sum);
+        event.getDocumentUploads().stream().map(DocumentUpload::getSize).reduce(0L, Long::sum);
     if (Long.sum(totalEventFileSize, multipartFile.getSize()) > documentConfig.getMaxTotalSize()) {
       throw new IllegalArgumentException(
           "Uploading file will exceed the maximum allowed total limit of "
               + documentConfig.getMaxTotalSize() + " bytes for event " + eventId
               + " (current total size is " + totalEventFileSize + " bytes, across "
-              + currentDocuments.size() + " files)");
+              + event.getDocumentUploads().size() + " files)");
     }
 
+    return tendersAPIModelUtils.buildDocumentSummary(documentUploadService.uploadDocument(event,
+        multipartFile, audience, fileDescription, principal));
+  }
+
+  /**
+   * Retrieve a document from the Tenders document upload store (DB+S3)
+   *
+   * @param procId
+   * @param eventId
+   * @param documentId
+   * @return
+   */
+  @Transactional
+  public DocumentAttachment getDocument(final Integer procId, final String eventId,
+      final String documentId, final String principal) {
+
+    log.debug("Get Document {} from Event {}", documentId, eventId);
+
     var event = validationService.validateProjectAndEventIds(procId, eventId);
+    var documentUpload = findDocumentUploadInEvent(event, documentId);
+    var documentKey = DocumentKey.fromString(documentId);
+    log.debug("Retrieving Document {}", documentKey.getFileName());
+
+    return DocumentAttachment.builder()
+        .data(documentUploadService.retrieveDocument(documentUpload, principal))
+        .fileName(documentKey.getFileName())
+        .contentType(MediaType.parseMediaType(documentUpload.getMimetype())).build();
+  }
+
+  /**
+   * Delete a document from the Tenders document upload store (DB+S3)
+   *
+   * @param procId
+   * @param eventId
+   * @param documentId
+   */
+  @Transactional
+  public void deleteDocument(final Integer procId, final String eventId, final String documentId) {
+    log.debug("Delete Document {} from Event {}", documentId, eventId);
+
+    var event = validationService.validateProjectAndEventIds(procId, eventId);
+    var documentUpload = findDocumentUploadInEvent(event, documentId);
+    var documentKey = DocumentKey.fromString(documentId);
+    log.debug("Deleting Document {}", documentKey.getFileName());
+
+    documentUploadService.deleteDocument(documentUpload);
+  }
+
+  /**
+   * Publish an Rfx in Jaggaer
+   *
+   * @param procId
+   * @param eventId
+   */
+  @Transactional
+  public void publishEvent(final Integer procId, final String eventId,
+      final PublishDates publishDates, final String principal) {
+
+    var jaggaerUserId = userProfileService.resolveBuyerUserByEmail(principal)
+        .orElseThrow(() -> new AuthorisationFailureException(ERR_MSG_JAGGAER_USER_NOT_FOUND))
+        .getUserId();
+
+    var procurementEvent = validationService.validateProjectAndEventIds(procId, eventId);
+    var exportRfxResponse = jaggaerService.getRfx(procurementEvent.getExternalEventId());
+    var status = jaggaerAPIConfig.getRfxStatusToTenderStatus()
+        .get(exportRfxResponse.getRfxSetting().getStatusCode());
+
+    if (TenderStatus.PLANNED != status) {
+      throw new IllegalArgumentException(
+          "You cannot publish an event unless it is in a 'planned' state");
+    }
+
+    // Fetch and upload all documents
+    procurementEvent.getDocumentUploads().stream().forEach(documentUpload -> {
+      var docKey = DocumentKey.fromString(documentUpload.getDocumentId());
+      var multipartFile = new ByteArrayMultipartFile(
+          documentUploadService.retrieveDocument(documentUpload, principal), docKey.getFileName(),
+          documentUpload.getMimetype());
+
+      eventUploadDocument(procurementEvent, docKey.getFileName(),
+          documentUpload.getDocumentDescription(), documentUpload.getAudience(), multipartFile);
+    });
+
+    validationService.validatePublishDates(publishDates);
+    jaggaerService.publishRfx(procurementEvent, publishDates, jaggaerUserId);
+  }
+
+  /**
+   * Upload a document to the Jaggaer event
+   *
+   * @param event
+   * @param fileName
+   * @param fileDescription
+   * @param audience
+   * @param multipartFile
+   */
+  public void eventUploadDocument(final ProcurementEvent event, final String fileName,
+      final String fileDescription, final DocumentAudienceType audience,
+      final MultipartFile multipartFile) {
+
     var rfxSetting = RfxSetting.builder().rfxId(event.getExternalEventId())
         .rfxReferenceCode(event.getExternalReferenceId()).build();
     var attachment =
@@ -550,54 +641,6 @@ public class ProcurementEventService {
 
     var update = new CreateUpdateRfx(OperationCode.CREATEUPDATE, rfx);
     jaggaerService.uploadDocument(multipartFile, update);
-
-    var docs = getDocumentSummaries(procId, eventId);
-    return docs.stream().filter(d -> d.getFileName().equals(fileName)).findFirst().orElseThrow(
-        () -> new IllegalStateException("There was an unexpected error uploading the document"));
-  }
-
-  /**
-   * Retrieve a document attached to an Rfx in Jaggaer.
-   *
-   * @param procId
-   * @param eventId
-   * @param documentId
-   * @return
-   */
-  public DocumentAttachment getDocument(final Integer procId, final String eventId,
-      final String documentId) {
-
-    log.debug("Get Document {} from Event {}", documentId, eventId);
-
-    validationService.validateProjectAndEventIds(procId, eventId);
-    var documentKey = DocumentKey.fromString(documentId);
-    log.debug("Retrieving Document {}", documentKey.getFileName());
-    return jaggaerService.getDocument(documentKey.getFileId(), documentKey.getFileName());
-  }
-
-  /**
-   * Publish an Rfx in Jaggaer
-   *
-   * @param procId
-   * @param eventId
-   */
-  public void publishEvent(final Integer procId, final String eventId,
-      final PublishDates publishDates, final String principal) {
-
-    var jaggaerUserId = userProfileService.resolveBuyerUserByEmail(principal)
-        .orElseThrow(() -> new AuthorisationFailureException(JAGGAER_USER_NOT_FOUND)).getUserId();
-
-    var procurementEvent = validationService.validateProjectAndEventIds(procId, eventId);
-    var exportRfxResponse = jaggaerService.getRfx(procurementEvent.getExternalEventId());
-    var status = jaggaerAPIConfig.getRfxStatusToTenderStatus()
-        .get(exportRfxResponse.getRfxSetting().getStatusCode());
-
-    if (TenderStatus.PLANNED != status) {
-      throw new IllegalArgumentException(
-          "You cannot publish an event unless it is in a 'planned' state");
-    }
-    validationService.validatePublishDates(publishDates);
-    jaggaerService.publishRfx(procurementEvent, publishDates, jaggaerUserId);
   }
 
   /**
@@ -732,7 +775,7 @@ public class ProcurementEventService {
         var om = retryableTendersDBDelegate
             .findOrganisationMappingByExternalOrganisationId(s.getCompanyData().getId())
             .orElseThrow(() -> new IllegalArgumentException(
-                String.format(SUPPLIER_NOT_FOUND_MSG, s.getCompanyData().getId())));
+                String.format(ERR_MSG_FMT_SUPPLIER_NOT_FOUND, s.getCompanyData().getId())));
 
         var org = new OrganizationReference();
         org.setId(String.valueOf(om.getOrganisationId()));
@@ -786,6 +829,13 @@ public class ProcurementEventService {
         .rfxReferenceCode(event.getExternalReferenceId()).build();
     var rfx = Rfx.builder().rfxSetting(rfxSetting).suppliersList(suppliersList).build();
     jaggaerService.createUpdateRfx(rfx, OperationCode.UPDATE_RESET);
+  }
+
+  DocumentUpload findDocumentUploadInEvent(final ProcurementEvent event, final String documentId) {
+    return event.getDocumentUploads().stream()
+        .filter(du -> Objects.equals(du.getDocumentId(), documentId)).findFirst()
+        .orElseThrow(() -> new ResourceNotFoundException(
+            String.format(ERR_MSG_FMT_DOCUMENT_NOT_FOUND, documentId)));
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/documentupload/DocumentUploadScheduledTask.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/documentupload/DocumentUploadScheduledTask.java
@@ -1,0 +1,33 @@
+package uk.gov.crowncommercial.dts.scale.cat.service.documentupload;
+
+import javax.transaction.Transactional;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.VirusCheckStatus;
+import uk.gov.crowncommercial.dts.scale.cat.repo.DocumentUploadRepo;
+
+/**
+ *
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DocumentUploadScheduledTask {
+
+  static final String PRINCIPAL = "TENDERS_API_DOC_UPLOAD_DEAMON";
+
+  private final DocumentUploadService documentUploadService;
+  private final DocumentUploadRepo documentUploadRepo;
+
+  @Scheduled(fixedDelayString = "PT1M")
+  @Transactional
+  void checkDocumentStatus() {
+    var unprocessedDocuments = documentUploadRepo.findByExternalStatus(VirusCheckStatus.PROCESSING);
+    log.debug("Begin scheduled processing of {} unprocessed documents",
+        unprocessedDocuments.size());
+    documentUploadService.processDocuments(unprocessedDocuments, PRINCIPAL);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/documentupload/DocumentUploadService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/documentupload/DocumentUploadService.java
@@ -1,0 +1,248 @@
+package uk.gov.crowncommercial.dts.scale.cat.service.documentupload;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static uk.gov.crowncommercial.dts.scale.cat.config.DocumentUploadAPIConfig.KEY_URI_TEMPLATE;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.commons.io.IOUtils;
+import org.apache.tika.Tika;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.crowncommercial.dts.scale.cat.config.DocumentUploadAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.config.paas.AWSS3Service;
+import uk.gov.crowncommercial.dts.scale.cat.exception.DocumentUploadApplicationException;
+import uk.gov.crowncommercial.dts.scale.cat.exception.TendersDBDataException;
+import uk.gov.crowncommercial.dts.scale.cat.model.DocumentKey;
+import uk.gov.crowncommercial.dts.scale.cat.model.documentupload.DocumentStatus;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.DocumentUpload;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.Timestamps;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.VirusCheckStatus;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.DocumentAudienceType;
+import uk.gov.crowncommercial.dts.scale.cat.repo.DocumentUploadRepo;
+import uk.gov.crowncommercial.dts.scale.cat.repo.ProcurementEventRepo;
+import uk.gov.crowncommercial.dts.scale.cat.service.WebclientWrapper;
+
+/**
+ * Handles interactions with the external Document Upload Service (including its S3 bucket) and the
+ * Tenders Document Store (database record + S3 object)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DocumentUploadService {
+
+  static final String TENDERS_S3_OBJECT_KEY_FORMAT = "/%s/%s/%s";
+  static final Tika TIKA = new Tika();
+
+  private final AmazonS3 documentUploadS3Client;
+  private final AmazonS3 tendersS3Client;
+  private final AWSS3Service tendersS3Service;
+  private final DocumentUploadAPIConfig apiConfig;
+  private final WebClient documentUploadWebClient;
+  private final WebclientWrapper webclientWrapper;
+  private final DocumentUploadRepo documentUploadRepo;
+  private final ProcurementEventRepo procurementEventRepo;
+
+  /**
+   * Upload a new document for processing by the Document Upload Service
+   *
+   * @param event
+   * @param multipartFile
+   * @param audience
+   * @param documentDescription
+   * @param principal
+   * @return
+   */
+  public DocumentUpload uploadDocument(final ProcurementEvent event,
+      final MultipartFile multipartFile, final DocumentAudienceType audience,
+      final String documentDescription, final String principal) {
+
+    var mimetype = TIKA.detect(multipartFile.getOriginalFilename());
+    final MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+    parts.add("typeValidation[]", mimetype);
+    parts.add("sizeValidation", multipartFile.getSize());
+    parts.add("documentFile", multipartFile.getResource());
+
+    final var documentStatus = ofNullable(
+        documentUploadWebClient.post().uri(apiConfig.getPostDocument().get(KEY_URI_TEMPLATE))
+            .contentType(MediaType.MULTIPART_FORM_DATA).body(BodyInserters.fromMultipartData(parts))
+            .retrieve().bodyToMono(DocumentStatus.class).block())
+                .orElseThrow(() -> new DocumentUploadApplicationException(""));
+
+    // Create document ID from event ID plus size (may be truncated)
+    var docKey = new DocumentKey(event.getId() + (int) multipartFile.getSize(),
+        multipartFile.getOriginalFilename(), audience);
+
+    var documentUpload = DocumentUpload.builder().procurementEvent(event)
+        .documentId(docKey.getDocumentId()).externalDocumentId(documentStatus.getId())
+        .externalStatus(VirusCheckStatus.fromName(documentStatus.getState())).audience(audience)
+        .size(multipartFile.getSize()).documentDescription(documentDescription).mimetype(mimetype)
+        .timestamps(Timestamps.createTimestamps(principal)).build();
+    event.getDocumentUploads().add(documentUpload);
+    procurementEventRepo.save(event);
+
+    return documentUpload;
+  }
+
+  /**
+   * Delete a document from Tenders document store
+   *
+   * @param event
+   * @param documentId
+   */
+  public void deleteDocument(final DocumentUpload documentUpload) {
+    var event = documentUpload.getProcurementEvent();
+
+    // Document should only exist in Tenders S3 if safe
+    if (documentUpload.getExternalStatus() == VirusCheckStatus.SAFE) {
+      tendersS3Client.deleteObject(tendersS3Service.getCredentials().getBucketName(),
+          tendersS3ObjectKey(event.getProject().getId(), event.getEventID(),
+              documentUpload.getDocumentId()));
+    }
+    documentUploadRepo.delete(documentUpload);
+    event.getDocumentUploads().remove(documentUpload);
+    procurementEventRepo.save(event);
+  }
+
+  /**
+   * Retrieve the given document from the Tenders document store
+   *
+   * @param event
+   * @param documentUpload
+   * @param principal
+   * @return
+   */
+  @SneakyThrows
+  public byte[] retrieveDocument(final DocumentUpload documentUpload, final String principal) {
+    var documentId = documentUpload.getDocumentId();
+    var event = documentUpload.getProcurementEvent();
+    var tendersS3ObjectKey =
+        tendersS3ObjectKey(event.getProject().getId(), event.getEventID(), documentId);
+
+    switch (documentUpload.getExternalStatus()) {
+      case SAFE:
+        // Get document from Tenders S3
+        return getFromTendersS3(tendersS3ObjectKey);
+
+      case PROCESSING:
+        // Invoke processing of remote S3 / throw error if still processing / unsafe?
+        processDocuments(Set.of(documentUpload), principal);
+        if (documentUpload.getExternalStatus() == VirusCheckStatus.SAFE) {
+          return getFromTendersS3(tendersS3ObjectKey);
+        } else {
+          throw new DocumentUploadApplicationException("TODO - ??");
+        }
+
+      case UNSAFE:
+        throw new DocumentUploadApplicationException(
+            "Requested document was found to contain threats (viruses) and is unavilable to download");
+
+      default:
+        throw new TendersDBDataException(
+            format("Document upload has unknown state [%s] in Tenders DB",
+                documentUpload.getExternalStatus()));
+    }
+  }
+
+  /**
+   * Process a collection of (unprocessed) document uploads. For each document, fitst check if the
+   * document has already been processed (e.g. by a different thread) and if not, get the processing
+   * status from the external document upload service and action accordingly - if SAFE, copy the
+   * document (object) from the remote S3 bucket into the Tenders S3 bucket. If UNSAFE, do not copy
+   * but in both scenarios update the TDB document upload record
+   *
+   * @param unprocessedDocuments
+   * @param principal
+   */
+  void processDocuments(final Collection<DocumentUpload> unprocessedDocuments,
+      final String principal) {
+    unprocessedDocuments.stream().forEach(unprocessedDocUpload -> {
+
+      // Ensure processing of each document takes place only once
+      // TODO: Replace with Blocking queue + timeout to avoid deadlocks
+      synchronized (unprocessedDocUpload) {
+        // Pre-check that the document hasn't just been processed by separate thread
+        if (unprocessedDocUpload.getExternalStatus() != VirusCheckStatus.PROCESSING) {
+          log.debug("Document [{}] already processed - skipping",
+              unprocessedDocUpload.getDocumentId());
+          return;
+        }
+
+        var documentStatusResponse = webclientWrapper.getOptionalResource(DocumentStatus.class,
+            documentUploadWebClient, apiConfig.getTimeoutDuration(),
+            apiConfig.getGetDocumentRecord().get(KEY_URI_TEMPLATE),
+            unprocessedDocUpload.getExternalDocumentId());
+
+        documentStatusResponse.ifPresentOrElse(documentStatus -> {
+
+          if (Objects.equals(apiConfig.getDocumentStateSafe(), documentStatus.getState())) {
+            copyDocumentFromRemoteS3(unprocessedDocUpload, documentStatus);
+            unprocessedDocUpload.setExternalStatus(VirusCheckStatus.SAFE);
+            unprocessedDocUpload.setTimestamps(
+                Timestamps.updateTimestamps(unprocessedDocUpload.getTimestamps(), principal));
+          } else if (Objects.equals(apiConfig.getDocumentStateUnsafe(),
+              documentStatus.getState())) {
+            unprocessedDocUpload.setExternalStatus(VirusCheckStatus.UNSAFE);
+            unprocessedDocUpload.setTimestamps(
+                Timestamps.updateTimestamps(unprocessedDocUpload.getTimestamps(), principal));
+            log.debug("Unsafe document identified, ID: [{}], event: [{}]",
+                unprocessedDocUpload.getId(),
+                unprocessedDocUpload.getProcurementEvent().getEventID());
+          }
+          documentUploadRepo.save(unprocessedDocUpload);
+
+        }, () -> log.error("Unable to get status from doc upload service for document ID: [{}]",
+            unprocessedDocUpload.getDocumentId()));
+      }
+    });
+  }
+
+  private void copyDocumentFromRemoteS3(final DocumentUpload unprocessedDocUpload,
+      final DocumentStatus documentStatus) {
+    var remoteS3Object = documentUploadS3Client.getObject(apiConfig.getS3Bucket(),
+        documentStatus.getDocumentFile().getUrl());
+
+    var tendersS3ObjectKey =
+        tendersS3ObjectKey(unprocessedDocUpload.getProcurementEvent().getProject().getId(),
+            unprocessedDocUpload.getProcurementEvent().getEventID(),
+            unprocessedDocUpload.getDocumentId());
+
+    var s3ObjectMetadata = new ObjectMetadata();
+    s3ObjectMetadata.setContentType(unprocessedDocUpload.getMimetype());
+    s3ObjectMetadata.setContentLength(unprocessedDocUpload.getSize());
+
+    log.debug(
+        "Copying object: [{}] from remote S3 bucket: [{}] to object: [{}] in Tenders S3 bucket: [{}]",
+        documentStatus.getDocumentFile().getUrl(), apiConfig.getS3Bucket(), tendersS3ObjectKey,
+        tendersS3Service.getCredentials().getBucketName());
+
+    tendersS3Client.putObject(tendersS3Service.getCredentials().getBucketName(), tendersS3ObjectKey,
+        remoteS3Object.getObjectContent(), s3ObjectMetadata);
+  }
+
+  private byte[] getFromTendersS3(final String tendersS3ObjectKey) throws IOException {
+    var tendersS3Object = tendersS3Client
+        .getObject(tendersS3Service.getCredentials().getBucketName(), tendersS3ObjectKey);
+    return IOUtils.toByteArray(tendersS3Object.getObjectContent());
+  }
+
+  private String tendersS3ObjectKey(final Integer projectId, final String eventId,
+      final String documentId) {
+    return String.format(TENDERS_S3_OBJECT_KEY_FORMAT, projectId, eventId, documentId);
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
@@ -1,6 +1,5 @@
 package uk.gov.crowncommercial.dts.scale.cat.utils;
 
-import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -11,6 +10,7 @@ import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.model.ApiError;
 import uk.gov.crowncommercial.dts.scale.cat.model.DocumentKey;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.DocumentUpload;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Attachment;
@@ -120,6 +120,14 @@ public class TendersAPIModelUtils {
     doc.setDescription(attachment.getFileDescription());
     doc.setAudience(audienceType);
     return doc;
+  }
+
+  public DocumentSummary buildDocumentSummary(final DocumentUpload documentUpload) {
+    var docKey = DocumentKey.fromString(documentUpload.getDocumentId());
+
+    return new DocumentSummary().id(documentUpload.getDocumentId()).fileName(docKey.getFileName())
+        .fileSize(documentUpload.getSize()).description(documentUpload.getDocumentDescription())
+        .audience(documentUpload.getAudience());
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -175,6 +175,18 @@ config:
         uriTemplate: /user-profiles/contacts?user-id={email}
       getOrganisation:
         uriTemplate: /organisation-profiles/{org-id}
+        
+    documentUpload:
+      timeoutDuration: 10
+      awsRegion: eu-west-2
+      documentStateProcessing: processing
+      documentStateSafe: safe
+      documentStateUnsafe: unsafe
+      postDocument:
+        uriTemplate: /documents
+      getDocumentRecord:
+        uriTemplate: /documents/{document-id}
+      
   #flags:
     # devMode: "SET IN ENV"
 ---

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-
 import java.time.Duration;
 import java.util.*;
 import org.junit.jupiter.api.Test;
@@ -22,6 +21,7 @@ import uk.gov.crowncommercial.dts.scale.cat.config.DocumentConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.OcdsConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.JaggaerApplicationException;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.DocumentUpload;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent.ProcurementEventBuilder;
@@ -32,6 +32,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.SubUsers.SubUser;
 import uk.gov.crowncommercial.dts.scale.cat.repo.*;
 import uk.gov.crowncommercial.dts.scale.cat.repo.readonly.CalculationBaseRepo;
 import uk.gov.crowncommercial.dts.scale.cat.service.ca.AssessmentService;
+import uk.gov.crowncommercial.dts.scale.cat.service.documentupload.DocumentUploadService;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 
 /**
@@ -150,6 +151,9 @@ class ProcurementEventServiceTest {
 
   @MockBean
   private SupplierSelectionRepo supplierSelectionRepo;
+
+  @MockBean
+  private DocumentUploadService documentUploadService;
 
   private final CreateEvent createEvent = new CreateEvent();
 
@@ -799,10 +803,26 @@ class ProcurementEventServiceTest {
 
     var publishDates = mock(PublishDates.class);
 
+    var documentData1 = new byte[] {'a', 'b', 'c'};
+    var documentData2 = new byte[] {'1', '2', '3'};
+
     var procurementProject =
         ProcurementProject.builder().caNumber(CA_NUMBER).lotNumber(LOT_NUMBER).build();
     var procurementEvent = ProcurementEvent.builder().project(procurementProject).eventType("RFI")
         .externalEventId(RFX_ID).externalReferenceId(RFX_REF_CODE).build();
+
+    var documentUpload1 = DocumentUpload.builder().id(1)
+        .documentId("YnV5ZXItMjM3MDU4LW5pY2VwZGYucGRm").mimetype("application/pdf")
+        .documentDescription("A PDF").audience(DocumentAudienceType.BUYER).build();
+
+    var documentUpload2 = DocumentUpload.builder().id(2)
+        .documentId("c3VwcGxpZXItNjU5MzUtbmljZXBuZy5wbmc=").mimetype("image/png")
+        .documentDescription("A PNG").audience(DocumentAudienceType.SUPPLIER).build();
+
+    var documentUploads = Set.of(documentUpload1, documentUpload2);
+    procurementEvent.setDocumentUploads(documentUploads);
+    documentUpload1.setProcurementEvent(procurementEvent);
+    documentUpload2.setProcurementEvent(procurementEvent);
 
     var rfxSetting = RfxSetting.builder().statusCode(100).rfxId(RFX_ID)
         .shortDescription(ORIGINAL_EVENT_NAME).longDescription(DESCRIPTION).build();
@@ -814,11 +834,16 @@ class ProcurementEventServiceTest {
     when(jaggaerService.getRfx(RFX_ID)).thenReturn(rfxResponse);
     when(validationService.validateProjectAndEventIds(PROC_PROJECT_ID, PROC_EVENT_ID))
         .thenReturn(procurementEvent);
+    when(documentUploadService.retrieveDocument(documentUpload1, PRINCIPAL))
+        .thenReturn(documentData1);
+    when(documentUploadService.retrieveDocument(documentUpload2, PRINCIPAL))
+        .thenReturn(documentData2);
 
     // Invoke & assert
     procurementEventService.publishEvent(PROC_PROJECT_ID, PROC_EVENT_ID, publishDates, PRINCIPAL);
-    verify(jaggaerService).publishRfx(procurementEvent, publishDates, JAGGAER_USER_ID);
 
+    verify(jaggaerService, times(2)).uploadDocument(any(), any());
+    verify(jaggaerService).publishRfx(procurementEvent, publishDates, JAGGAER_USER_ID);
   }
 
   @Test

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ValidationServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
@@ -27,8 +26,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.UpdateEvent;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
 import uk.gov.crowncommercial.dts.scale.cat.service.ca.AssessmentService;
 
-@SpringBootTest(classes = {ValidationService.class, ApplicationConfig.class},
-    webEnvironment = WebEnvironment.NONE)
+@SpringBootTest(classes = {ValidationService.class}, webEnvironment = WebEnvironment.NONE)
 @EnableConfigurationProperties(JaggaerAPIConfig.class)
 class ValidationServiceTest {
 
@@ -47,6 +45,9 @@ class ValidationServiceTest {
 
   @MockBean
   AssessmentService assessmentService;
+
+  @MockBean
+  Clock clock;
 
   @Test
   void testValidateEventId_success() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-2642 (Doc upload service retrofit)
SCAT-4121 (virus scan)
SCAT-3337 (Delete document endpoint)

### Change description ###
Integrated the external Document Upload service for scanning and temporary storage of uploaded documents.  Once documents are marked `safe` by the external system, then either via the new scheduled task or on request they are retrieved from the Doc Upload service's S3 bucket and copied to the 'local' Tenders S3 bucket, and the DB record updated.  There they remain until the event is published.

NB: Draft - publish endpoint still needs a bit of debugging, missing tests, needs a bit of a tidy.  But wanted to give visibility of it.  Note to run locally requires a `VCAP_SERVICES` environment variable mimicking the S3 bucket creds from GOV.UK PaaS, plus some other new env vars.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
