### PR TITLE
Bugfix - create dimension weighting if none exists when creating a requirement

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
@@ -624,15 +624,17 @@ public class AssessmentService {
           dimensionSubmissionTypes.stream().map(DimensionSubmissionType::getSubmissionType)
               .map(SubmissionType::getCode).collect(Collectors.toSet());
 
-      submissionTypes.addAll(dimensionRequirement.getIncludedCriteria().stream().map(cd -> {
-        if (!validToolSubmissionTypeIDs.contains(cd.getCriterionId())) {
-          throw new ValidationException(
-              format(ERR_MSG_FMT_SUBMISSION_TYPE_NOT_FOUND, cd.getCriterionId()));
-        }
-        return dimensionSubmissionTypes.stream()
-            .filter(tst -> Objects.equals(tst.getSubmissionType().getCode(), cd.getCriterionId()))
-            .findFirst().get();
-      }).collect(Collectors.toSet()));
+      if (dimensionRequirement.getIncludedCriteria() != null) {
+        submissionTypes.addAll(dimensionRequirement.getIncludedCriteria().stream().map(cd -> {
+          if (!validToolSubmissionTypeIDs.contains(cd.getCriterionId())) {
+            throw new ValidationException(
+                format(ERR_MSG_FMT_SUBMISSION_TYPE_NOT_FOUND, cd.getCriterionId()));
+          }
+          return dimensionSubmissionTypes.stream()
+              .filter(tst -> Objects.equals(tst.getSubmissionType().getCode(), cd.getCriterionId()))
+              .findFirst().get();
+        }).collect(Collectors.toSet()));
+      }
     }
 
     return submissionTypes;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
@@ -409,6 +409,19 @@ public class AssessmentService {
           requirement.getRequirementId(), dimensionId));
     }
 
+    // If no Dimension Weighting has been created yet - add it (the GET Assessment request requires
+    // a Dimension Weighting in place)
+    var dimensionWeighting = assessment.getDimensionWeightings().stream()
+        .filter(dw -> dw.getDimension().getId().equals(dimension.getId())).findAny();
+    if (dimensionWeighting.isEmpty()) {
+      var newDimensionWeighting = new AssessmentDimensionWeighting();
+      newDimensionWeighting.setAssessment(assessment);
+      newDimensionWeighting.setDimension(dimension);
+      newDimensionWeighting.setWeightingPercentage(BigDecimal.ZERO);
+      newDimensionWeighting.setTimestamps(createTimestamps(principal));
+      retryableTendersDBDelegate.save(newDimensionWeighting);
+    }
+
     // Create the AssessmentSelection for the Dimension/Requirement/Assessment if it doesn't exist
     AssessmentSelection selection;
     var response = assessment.getAssessmentSelections().stream()


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Found an issue where if you created a requirement without first creating a dimension weighting - with a weighting of 0 (by adding/updating dimension) - got an error when trying to get the Assessment - as response is hierarchical - so all requirements need to exist within a dimension.

Also made another small change to avoid a 500 error if no includedCriteria are supplied when updating a Dimension. Not sure whether this should be a 400 - but thought being permissive maybe best for this.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
