### PR TITLE
develop -> release/int

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
@@ -338,6 +338,9 @@ public class AssessmentService {
         dimensionWeighting
             .setWeightingPercentage(new BigDecimal(dimensionRequirement.getWeighting()));
       }
+
+
+
       dimensionWeighting
           .setTimestamps(updateTimestamps(dimensionWeighting.getTimestamps(), principal));
       dimensionWeighting.setDimensionSubmissionTypes(
@@ -350,7 +353,10 @@ public class AssessmentService {
     }
 
     // Save Dimension Weighting
-    retryableTendersDBDelegate.save(dimensionWeighting);
+    // Note: Save via an assessment - as we need the assessment to be updated within the transaction
+    // for updateRequirements method to be aware we have already created a dimensionWeighting
+    assessment.getDimensionWeightings().add(dimensionWeighting);
+    retryableTendersDBDelegate.save(assessment);
 
     // If overwriteRequirements flag is true, remove any existing AssessmentSelections not included
     // in the request


### PR DESCRIPTION
Update requirement can be approached 2 ways - direct via controller, or
indirect via updateDimension. If a dimensionWeighting was created in
updateDimension - it was not visible in the assessment (think because of
JPA L1 cache). So changed way DW was persisted (via assessment).

### JIRA link (if applicable) ###



### Change description ###



### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
