### PR TITLE
Fix Maven download link to a permalink from archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk: openjdk17
 script: 
-  # Install latest version of Maven compatible with JDK 17
-  - wget https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.tar.gz -P /tmp
+  # Install latest version of Maven compatible with JDK 17. Use archives for permalink to fixed version
+  - wget https://archive.apache.org/dist/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.tar.gz -P /tmp
   - sudo tar xf /tmp/apache-maven-*.tar.gz -C /usr/local/bin/
   - export M2_HOME=/usr/local/bin/apache-maven-3.8.5
   - export PATH=${M2_HOME}/bin:${PATH}


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Fix from SCAT-4915 JDK 17 updates - using non-permanent download URL for Maven (noticed last build on DEV failed because of a 404 when attempting to download Maven 3.8.5 via the mirror - switched to archives).


### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
