### PR TITLE
Fix S3 export, Jaggaer webclient and RPA export

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/JaggaerClientConfig.java
@@ -20,6 +20,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.JettyClientHttpConnector;
 import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.endpoint.DefaultClientCredentialsTokenResponseClient;
@@ -27,8 +29,6 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResp
 import org.springframework.security.oauth2.client.endpoint.OAuth2ClientCredentialsGrantRequest;
 import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
@@ -71,16 +71,18 @@ public class JaggaerClientConfig {
 
   @Bean
   public OAuth2AuthorizedClientManager authorizedClientManager(
-      final ClientRegistrationRepository clientRegistrationRepository,
-      final OAuth2AuthorizedClientRepository authorizedClientRepository) {
+      final ClientRegistrationRepository clientRegistrationRepository) {
 
     var authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
         .clientCredentials(
             configurer -> configurer.accessTokenResponseClient(accessTokenResponseClient()))
         .build();
 
-    var authorizedClientManager = new DefaultOAuth2AuthorizedClientManager(
-        clientRegistrationRepository, authorizedClientRepository);
+    var authorizedClientService =
+        new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+
+    var authorizedClientManager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository, authorizedClientService);
     authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
 
     return authorizedClientManager;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/BuyerUserDetails.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/entity/BuyerUserDetails.java
@@ -25,7 +25,7 @@ public class BuyerUserDetails {
   String userPassword;
 
   @Column(name = "exported")
-  boolean exported;
+  Boolean exported;
 
   @Column(name = "created_by", updatable = false)
   String createdBy;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
@@ -271,8 +271,13 @@ public class RetryableTendersDBDelegate {
   }
 
   @TendersRetryable
-  public void saveAll(final Set<BuyerUserDetails> buyerUserDetails) {
-    buyerUserDetailsRepo.saveAll(buyerUserDetails);
+  public void saveAll(final Iterable<BuyerUserDetails> buyerUserDetails) {
+    buyerUserDetailsRepo.saveAllAndFlush(buyerUserDetails);
+  }
+
+  @TendersRetryable
+  public List<BuyerUserDetails> findAll() {
+    return buyerUserDetailsRepo.findAll();
   }
 
   /**

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementService.java
@@ -447,12 +447,12 @@ public class ProfileManagementService {
         userRegistrationNotificationConfig.getTargetEmail(), placeholders, "");
   }
 
-  private BuyerUserDetails saveBuyerDetails(String profile) {
+  private BuyerUserDetails saveBuyerDetails(final String profile) {
     var userProfile = userProfileService.resolveBuyerUserProfile(profile)
         .orElseThrow(() -> new ResourceNotFoundException(ERR_MSG_FMT_JAGGAER_USER_MISSING));
     return buyerDetailsRepo.save(BuyerUserDetails.builder().userId(userProfile.getUserId())
-        .userPassword(encryptionService.generateBuyerPassword()).createdAt(Instant.now())
-        .createdBy("Scheduler").build());
+        .userPassword(encryptionService.generateBuyerPassword()).exported(Boolean.FALSE)
+        .createdAt(Instant.now()).createdBy("ProfileManagement").build());
   }
 
   static SSOCodeData buildSSOCodeData(final String userId) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/RPAExportScheduledTask.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/RPAExportScheduledTask.java
@@ -3,10 +3,18 @@ package uk.gov.crowncommercial.dts.scale.cat.service;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.poifs.crypt.EncryptionInfo;
+import org.apache.poi.poifs.crypt.EncryptionMode;
+import org.apache.poi.poifs.crypt.Encryptor;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -16,6 +24,7 @@ import org.springframework.util.StringUtils;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.cat.config.RPATransferS3Config;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.BuyerUserDetails;
@@ -33,6 +42,7 @@ public class RPAExportScheduledTask {
   private final RetryableTendersDBDelegate retryableTendersDBDelegate;
   private final EncryptionService encryptionService;
   private final RPATransferS3Config rpaTransferS3Config;
+  private final UserProfileService userProfileService;
   private final AmazonS3 rpaTransferS3Client;
 
   // TODO: Update to cron pattern for once weekly export
@@ -40,17 +50,39 @@ public class RPAExportScheduledTask {
   public void scheduleSelfServiceBuyers() {
     log.info("Begin scheduled processing of unexported buyer records for RPA");
 
+    // Get list of all buyer userIds from CaS DB:
+    var buyerUserIds = retryableTendersDBDelegate.findAll().parallelStream()
+        .map(BuyerUserDetails::getUserId).toList();
+
+    // Get all self-serve buyers and retain any with SSO data and NOT in DB
+    var nonExportedJaggaerBuyers =
+        userProfileService.getSelfServiceBuyerCompany().getReturnSubUser().getSubUsers().stream()
+            .filter(subUser -> subUser.getSsoCodeData() != null)
+            .filter(subUser -> !buyerUserIds.contains(subUser.getUserId())).toList();
+
+    // Add new recs to DB
+    var newBuyerDetails = nonExportedJaggaerBuyers.stream()
+        .map(subUser -> BuyerUserDetails.builder().userId(subUser.getUserId())
+            .userPassword(encryptionService.generateBuyerPassword()).exported(Boolean.FALSE)
+            .createdAt(Instant.now()).createdBy("RPAExportScheduledTask").build())
+        .toList();
+    retryableTendersDBDelegate.saveAll(newBuyerDetails);
+    log.debug("Saving {} non exported Jaggaer user profiles to DB", newBuyerDetails.size());
+
+    // Query DB for non-exported buyers and go from there..
     var nonExportedBuyers = retryableTendersDBDelegate.findByExported(false);
+
     if (!nonExportedBuyers.isEmpty()) {
-      generateExcelSheet(nonExportedBuyers);
-      nonExportedBuyers.forEach(buyer -> buyer.setExported(true));
+      var workbook = generateWorkbook(nonExportedBuyers);
+      transferToS3(workbook);
+      nonExportedBuyers.forEach(buyer -> buyer.setExported(Boolean.TRUE));
       retryableTendersDBDelegate.saveAll(nonExportedBuyers);
     }
     log.info("Completed scheduled processing of {} buyer records for RPA",
         nonExportedBuyers.size());
   }
 
-  private void generateExcelSheet(final Set<BuyerUserDetails> usersList) {
+  private XSSFWorkbook generateWorkbook(final Set<BuyerUserDetails> buyerUsers) {
     var workbook = new XSSFWorkbook();
     var sheet = workbook.createSheet(SHEET_NAME);
     var row = sheet.createRow(0);
@@ -62,11 +94,8 @@ public class RPAExportScheduledTask {
     style.setFont(font);
     createCell(row, 0, "UserId", style);
     createCell(row, 1, "Password", style);
-    writeData(usersList, workbook);
-
-    // Encrypt workbook via password
-    workbook.setWorkbookPassword(rpaTransferS3Config.getWorkbookPassword(), null);
-    transferToS3(workbook);
+    writeData(buyerUsers, workbook);
+    return workbook;
   }
 
   private void createCell(final Row row, final int columnCount, final Object value,
@@ -82,16 +111,16 @@ public class RPAExportScheduledTask {
     cell.setCellStyle(style);
   }
 
-  private void writeData(final Set<BuyerUserDetails> usersList, final XSSFWorkbook workbook) {
+  private void writeData(final Set<BuyerUserDetails> buyerUsers, final XSSFWorkbook workbook) {
     var style = workbook.createCellStyle();
     var font = workbook.createFont();
     var sheet = workbook.getSheet(SHEET_NAME);
 
-    font.setFontHeight(14);
+    font.setFontHeight(12);
     style.setFont(font);
-    usersList.forEach(user -> {
-      var rowCount = 1;
-      var row = sheet.createRow(rowCount++);
+    var rowCount = new AtomicInteger(1);
+    buyerUsers.forEach(user -> {
+      var row = sheet.createRow(rowCount.getAndIncrement());
       var columnCount = 0;
       createCell(row, columnCount++, user.getUserId(), style);
       createCell(row, columnCount++, encryptionService.decryptPassword(user.getUserPassword()),
@@ -99,18 +128,49 @@ public class RPAExportScheduledTask {
     });
   }
 
+  @SneakyThrows
+  private ByteArrayOutputStream encryptWorkbook(final XSSFWorkbook workbook) {
+
+    try (POIFSFileSystem fs = new POIFSFileSystem()) {
+      EncryptionInfo info = new EncryptionInfo(EncryptionMode.agile);
+      // EncryptionInfo info = new EncryptionInfo(EncryptionMode.agile, CipherAlgorithm.aes256,
+      // HashAlgorithm.sha384, -1, -1, null);
+      Encryptor enc = info.getEncryptor();
+      enc.confirmPassword(rpaTransferS3Config.getWorkbookPassword());
+
+      var baos = new ByteArrayOutputStream();
+      workbook.write(baos);
+      workbook.close();
+
+      // Encrypt
+      // TODO - something not right here, file gets created and is password protected but Excel 2016
+      // not able to open it for some reason
+      try (OPCPackage opc = OPCPackage.create(baos); OutputStream os = enc.getDataStream(fs)) {
+        opc.save(os);
+      }
+
+      // Write encrypted to our output stream
+      try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+        fs.writeFilesystem(byteArrayOutputStream);
+        return byteArrayOutputStream;
+      }
+    }
+  }
+
   private void transferToS3(final XSSFWorkbook workbook) {
 
     var filename = DateTimeFormatter.ISO_DATE_TIME
         .format(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)).replace(":", "") + ".xlsx";
-    var objectPrefix =
-        StringUtils.hasText(rpaTransferS3Config.getObjectPrefix()) ? rpaTransferS3Config + "/" : "";
+    var objectPrefix = StringUtils.hasText(rpaTransferS3Config.getObjectPrefix())
+        ? rpaTransferS3Config.getObjectPrefix() + "/"
+        : "";
     var objectKey = objectPrefix + filename;
 
     var byteArrayOutputStream = new ByteArrayOutputStream();
     try {
       workbook.write(byteArrayOutputStream);
       var bytes = byteArrayOutputStream.toByteArray();
+      // var bytes = encryptWorkbook(workbook).toByteArray();
       var inputStream = new ByteArrayInputStream(bytes);
 
       var objectMetadata = new ObjectMetadata();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -206,8 +206,8 @@ config:
     s3:
       rpa:
         region: eu-west-2
-        # Default to on the hour every hour MON-FRI
-        exportSchedule: "0 0 * * * MON-FRI"
+        # Default to every 15 minutes in local/dev env
+        exportSchedule: "0 */15 * * * MON-FRI"
         
     agreementsService:
       # baseUrl: "SET IN ENV"


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-4842


### Change description ###
Follow up changes to get self-service buyers from Jaggaer, filter by SSO and contents of local table for RPA export.  Also switches the config of the Jaggaer webclient to the `AuthorizedClientServiceOAuth2AuthorizedClientManager` rather than the default impl which only works in the context of a HTTP request, therefore making it impossible to use from scheduled components.
**N.B**
Attempted to password-encrypt the workbook, but something not right with code - it works, and exported file is password protected but for some reason Excel cannot open it (prompts for password but then complains about file format).
I will try to revisit it - it's probably not far off but examples are not that clear on how to encrypt the workbook from memory rather than from a file.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
