### PR TITLE
Fix multi-cache bug in LD GET endpoint

### DIFF
--- a/iac/environments/sbx2/main.tf
+++ b/iac/environments/sbx2/main.tf
@@ -9,6 +9,6 @@ module "deploy-all" {
   environment = "sbx2"
   cf_username = var.cf_username
   cf_password = var.cf_password
-  instances   = 1
+  instances   = 2
   dev_mode    = true
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProfileManagementService.java
@@ -411,6 +411,15 @@ public class ProfileManagementService {
 
     // SSO verification built-in to search
     var buyerSubUser = userProfileService.resolveBuyerUserBySSOUserLogin(userId);
+
+    // If cache missing, refresh in case user has since been registered (by separate instance)
+    if (buyerSubUser.isEmpty()) {
+      userProfileService.refreshBuyerCache(userId);
+      buyerSubUser = userProfileService.resolveBuyerUserBySSOUserLogin(userId);
+      log.debug("Refreshed buyer user cache for [{}], now found? - [{}]", userId,
+          buyerSubUser.isPresent());
+    }
+
     buyerSubUser.ifPresent(su -> jaggaerRoles.add(BUYER));
 
     // SSO verification required


### PR DESCRIPTION
### JIRA link (if applicable) ###
CON-2488


### Change description ###
Fix user cache bug for LD endpoint.  Increased the instance count on SBX2 to mirror higher environments - this means two separate Buyer user cache instances, which we need to ensure are refreshed during and after a new user has been registered.


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
