### PR TITLE
Fix RPA scheduler so we catch data integrity exceptions and quit

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/repo/RetryableTendersDBDelegate.java
@@ -36,7 +36,6 @@ public class RetryableTendersDBDelegate {
   private final AssessmentResultRepo assessmentResultRepo;
   private final ProjectUserMappingRepo projectUserMappingRepo;
   private final SupplierSelectionRepo supplierSelectionRepo;
-  private final SupplierSubmissionRepo supplierSubmissionRepo;
   private final BuyerUserDetailsRepo buyerUserDetailsRepo;
 
   @TendersRetryable

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -206,8 +206,8 @@ config:
     s3:
       rpa:
         region: eu-west-2
-        # Default to every 15 minutes in local/dev env
-        exportSchedule: "0 */15 * * * MON-FRI"
+        # Default to once a week, midnight Monday
+        exportSchedule: "0 0 0 * * MON"
         
     agreementsService:
       # baseUrl: "SET IN ENV"


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-4842

### Change description ###
Catches and logs data integrity exceptions from save operation on buyer user details (if other scheduler instance has just inserted records for example)


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
