### PR TITLE
Add scores flag to GET assessments endpoint

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/AssessmentsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/AssessmentsController.java
@@ -1,7 +1,14 @@
 package uk.gov.crowncommercial.dts.scale.cat.controller;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.ValidationException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.springframework.core.io.InputStreamResource;
@@ -11,22 +18,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.cat.config.Constants;
 import uk.gov.crowncommercial.dts.scale.cat.exception.NotSupportedException;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.*;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.ca.CalculationBase;
 import uk.gov.crowncommercial.dts.scale.cat.service.ca.AssessmentService;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.ValidationException;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.List;
-import java.util.Optional;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RestController
 @RequestMapping(path = "/assessments", produces = APPLICATION_JSON_VALUE)
@@ -39,7 +37,7 @@ public class AssessmentsController extends AbstractRestController {
       "requirement-id in body [%s] does not match requirement-id in path [%s]";
 
   private static final String ERR_EMPTY_BODY = "Empty body";
-  private static final String NOT_SUPPORTED_MIME_TYPE  = "Mime Type application/json not supported";
+  private static final String NOT_SUPPORTED_MIME_TYPE = "Mime Type application/json not supported";
 
   private final AssessmentService assessmentService;
 
@@ -75,12 +73,13 @@ public class AssessmentsController extends AbstractRestController {
 
   @GetMapping("/{assessment-id}")
   public Assessment getAssessment(final @PathVariable("assessment-id") Integer assessmentId,
+      @RequestParam(defaultValue = "false", required = true) final Boolean scores,
       final JwtAuthenticationToken authentication) {
 
     var principal = getPrincipalFromJwt(authentication);
     log.info("getAssessment invoked on behalf of principal: {}", principal);
 
-    return assessmentService.getAssessment(assessmentId, Optional.of(principal));
+    return assessmentService.getAssessment(assessmentId, scores, Optional.of(principal));
   }
 
   @PutMapping("/{assessment-id}/dimensions/{dimension-id}")
@@ -140,26 +139,25 @@ public class AssessmentsController extends AbstractRestController {
   public ResponseEntity<InputStreamResource> getSupplierDimensionData(
       final @PathVariable("tool-id") Integer toolId,
       final @PathVariable("dimension-id") Integer dimensionId,
-      @RequestParam(name = "lot-id", required = false) Integer lotId,
-      @RequestParam(name = "suppliers", required = false) List<String> suppliers,
-      @RequestHeader(name = "mime-type", required = false, defaultValue = "text/csv")
-          String mimeType,
-      HttpServletResponse response, final JwtAuthenticationToken authentication)
+      @RequestParam(name = "lot-id", required = false) final Integer lotId,
+      @RequestParam(name = "suppliers", required = false) final List<String> suppliers,
+      @RequestHeader(name = "mime-type", required = false,
+          defaultValue = "text/csv") final String mimeType,
+      final HttpServletResponse response, final JwtAuthenticationToken authentication)
       throws IOException {
 
     var principal = getPrincipalFromJwt(authentication);
     log.info("getSupplierDimensionData invoked on behalf of principal: {}", principal);
 
-    if (mimeType.equals(APPLICATION_JSON_VALUE)) {
+    if (APPLICATION_JSON_VALUE.equals(mimeType)) {
       throw new NotSupportedException(NOT_SUPPORTED_MIME_TYPE);
     }
 
     var supplierDimensionData =
-        assessmentService.getSupplierDimensionData(toolId, dimensionId, lotId,suppliers);
+        assessmentService.getSupplierDimensionData(toolId, dimensionId, lotId, suppliers);
 
-
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    try (CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), CSVFormat.DEFAULT)) {
+    var out = new ByteArrayOutputStream();
+    try (var csvPrinter = new CSVPrinter(new PrintWriter(out), CSVFormat.DEFAULT)) {
       csvPrinter.printRecord("SupplierId", "RequirementName", "DimensionName", "AssessmentToolName",
           "SubmissionTypeName", "SubmissionValue", "DimensionWeightPercentage",
           "SelectionWeightPercentage");
@@ -171,13 +169,14 @@ public class AssessmentsController extends AbstractRestController {
       throw new RuntimeException("fail to import data to CSV file: " + e.getMessage());
     }
 
-    return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION,
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_DISPOSITION,
             "attachment; filename=" + String.format(SUPPLIER_DATA, toolId, dimensionId))
         .contentType(MediaType.parseMediaType("text/csv"))
         .body(new InputStreamResource(new ByteArrayInputStream(out.toByteArray())));
   }
 
-  private void writeRecord(CalculationBase calculationBase, CSVPrinter csvPrinter)
+  private void writeRecord(final CalculationBase calculationBase, final CSVPrinter csvPrinter)
       throws IOException {
     csvPrinter.printRecord(calculationBase.getSupplierId(), calculationBase.getRequirementName(),
         calculationBase.getDimensionName(), calculationBase.getAssessmentToolName(),

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -163,8 +163,8 @@ public class ProcurementEventService {
         returnAssessmentId = newAssessmentId;
         log.debug("Created new empty assessment: {}", newAssessmentId);
       } else {
-        var validatedAssessment = assessmentService
-            .getAssessment(createEvent.getNonOCDS().getAssessmentId(), Optional.empty());
+        var validatedAssessment = assessmentService.getAssessment(
+            createEvent.getNonOCDS().getAssessmentId(), Boolean.FALSE, Optional.empty());
         eventBuilder.assessmentId(validatedAssessment.getAssessmentId());
         returnAssessmentId = validatedAssessment.getAssessmentId();
         log.debug("Linking existing assessment: {} to new event",
@@ -502,7 +502,8 @@ public class ProcurementEventService {
     if (event.isTendersDBOnly()) {
       log.debug("Event {} is persisted in Tenders DB only {}", event.getEventID(),
           event.getEventType());
-      var assessment = assessmentService.getAssessment(event.getAssessmentId(), Optional.empty());
+      var assessment =
+          assessmentService.getAssessment(event.getAssessmentId(), Boolean.FALSE, Optional.empty());
       var dimensionWeightingCheck = assessment.getDimensionRequirements().stream()
           .map(DimensionRequirement::getWeighting).reduce(0, Integer::sum);
       if (dimensionWeightingCheck != 100) {
@@ -813,7 +814,8 @@ public class ProcurementEventService {
       TenderStatus statusCode;
       RfxSetting rfxSetting = null;
       if (event.getExternalEventId() == null) {
-        var assessment = assessmentService.getAssessment(event.getAssessmentId(), Optional.empty());
+        var assessment = assessmentService.getAssessment(event.getAssessmentId(), Boolean.FALSE,
+            Optional.empty());
         statusCode = TenderStatus.fromValue(assessment.getStatus().toString().toLowerCase());
       } else {
         // var exportRfxResponse = jaggaerService.getRfx(event.getExternalEventId());

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/AssessmentService.java
@@ -218,7 +218,7 @@ public class AssessmentService {
       summary.setExternalToolId(a.getTool().getExternalToolId());
       summary.setStatus(AssessmentStatus.fromValue(a.getStatus().toString().toLowerCase()));
       return summary;
-    }).collect(Collectors.toList());
+    }).toList();
   }
 
   /**
@@ -229,7 +229,7 @@ public class AssessmentService {
    * @return
    */
   @Transactional
-  public Assessment getAssessment(final Integer assessmentId,
+  public Assessment getAssessment(final Integer assessmentId, final Boolean includeScores,
       final Optional<String> principalForScores) {
 
     var assessment = retryableTendersDBDelegate.findAssessmentById(assessmentId)
@@ -272,22 +272,23 @@ public class AssessmentService {
                 }
               }
               return criterion;
-            }).collect(Collectors.toList()));
+            }).toList());
 
             return requirement;
-          }).collect(Collectors.toList());
+          }).toList();
 
       req.setRequirements(requirements);
 
       return req;
 
-    }).collect(Collectors.toList());
+    }).toList();
 
     var response = new Assessment();
-    // TODO: Calculate Scores - Nick suggested there may be a db flag to enable/disable this
-    principalForScores.ifPresent(principal -> response
-        .setScores(assessmentCalculationService.calculateSupplierScores(assessment, principal)));
 
+    if (includeScores) {
+      principalForScores.ifPresent(principal -> response
+          .setScores(assessmentCalculationService.calculateSupplierScores(assessment, principal)));
+    }
     response.setExternalToolId(assessment.getTool().getExternalToolId());
     response.setAssessmentId(assessmentId);
     response.setDimensionRequirements(dimensions);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/DocValueAdaptorsCA.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/DocValueAdaptorsCA.java
@@ -135,7 +135,7 @@ public class DocValueAdaptorsCA {
   private Assessment getAssessment(final Integer assessmentId,
       final ConcurrentMap<String, Object> requestCache) {
     return (Assessment) requestCache.computeIfAbsent(CACHE_KEY_ASSESSMENT,
-        k -> assessmentService.getAssessment(assessmentId, Optional.empty()));
+        k -> assessmentService.getAssessment(assessmentId, Boolean.FALSE, Optional.empty()));
   }
 
   private DimensionDefinition getDimensionDefinition(final String toolId, final String dimension,

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/AssessmentsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/AssessmentsControllerTest.java
@@ -42,7 +42,8 @@ import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 class AssessmentsControllerTest {
 
   private static final String ASSESSMENTS_PATH = "/assessments";
-  private static final String SUPPLIERS_FOR_DIMENSION_PATH = ASSESSMENTS_PATH+"/tools/{tool-id}/dimensions/{dimension-id}/data?lot-id=";
+  private static final String SUPPLIERS_FOR_DIMENSION_PATH =
+      ASSESSMENTS_PATH + "/tools/{tool-id}/dimensions/{dimension-id}/data?lot-id=";
   private static final String PRINCIPAL = "jsmith@ccs.org.uk";
   private static final Integer ASSESSMENT_ID = 1;
   private static final Integer LOT_ID = 1;
@@ -161,7 +162,7 @@ class AssessmentsControllerTest {
     requirement.setValues(List.of(criterion));
     dimensionRequirement.setRequirements(List.of(requirement));
 
-    when(assessmentService.getAssessment(ASSESSMENT_ID, Optional.of(PRINCIPAL)))
+    when(assessmentService.getAssessment(ASSESSMENT_ID, Boolean.FALSE, Optional.of(PRINCIPAL)))
         .thenReturn(assessment);
 
     mockMvc
@@ -212,16 +213,16 @@ class AssessmentsControllerTest {
   @Test
   void testGetSupplierByToolIdAndDimensionId_200_OK() throws Exception {
     List<String> suppliers = Arrays.asList("US-DUNS-210305433");
-    var suppliersData = new HashSet(Arrays.asList(1,2,3,4,5,6));
+    var suppliersData = new HashSet(Arrays.asList(1, 2, 3, 4, 5, 6));
 
-    when(assessmentService.getSupplierDimensionData(TOOL_ID,DIMENSION_ID,LOT_ID, suppliers))
+    when(assessmentService.getSupplierDimensionData(TOOL_ID, DIMENSION_ID, LOT_ID, suppliers))
         .thenReturn(suppliersData);
 
-    mockMvc.perform(get(SUPPLIERS_FOR_DIMENSION_PATH + LOT_ID, TOOL_ID, DIMENSION_ID).with(
-            validJwtReqPostProcessor).accept(MediaType.parseMediaType("text/csv"))).andDo(print())
-        .andExpect(status().isOk());
+    mockMvc
+        .perform(get(SUPPLIERS_FOR_DIMENSION_PATH + LOT_ID, TOOL_ID, DIMENSION_ID)
+            .with(validJwtReqPostProcessor).accept(MediaType.parseMediaType("text/csv")))
+        .andDo(print()).andExpect(status().isOk());
   }
-
 
   private List<CriterionDefinition> getTestCriteria() {
     var criterion = new CriterionDefinition();

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -772,7 +772,8 @@ class ProcurementEventServiceTest {
         .thenReturn(event);
     when(organisationMappingRepo.findByOrganisationIdIn(Set.of(SUPPLIER_ID)))
         .thenReturn(Set.of(mapping));
-    when(assessmentService.getAssessment(ASSESSMENT_ID, Optional.empty())).thenReturn(assessment);
+    when(assessmentService.getAssessment(ASSESSMENT_ID, Boolean.FALSE, Optional.empty()))
+        .thenReturn(assessment);
 
     // Invoke
     var thrown = Assertions.assertThrows(ValidationException.class, () -> procurementEventService


### PR DESCRIPTION
### JIRA link (if applicable) ###
SCAT-5469 (amongst others probably)


### Change description ###
Add a new `scores=false|true` flag to the CA `GET /assessments/{assessment-id}` endpoint, defaulting to `false` to prevent the CA calculation being hit on every request to get an assessment.


### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
