### PR TITLE
JaggaerSupplierPush will always use JaggaerStore for DOS6

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/processors/SupplierStore.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/processors/SupplierStore.java
@@ -5,6 +5,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.generated.EventSuppliers;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Supplier;
 
 import java.util.List;
+import java.util.Map;
 
 public interface SupplierStore {
     public EventSuppliers getSuppliers(ProcurementEvent event, String principal);
@@ -12,6 +13,8 @@ public interface SupplierStore {
     public EventSuppliers storeSuppliers(ProcurementEvent event, EventSuppliers eventSuppliers, String principal);
 
     public List<Supplier> storeSuppliers(ProcurementEvent event, List<Supplier> suppliers, boolean overWrite, String principal);
+
+    public List<Supplier> storeSuppliers(ProcurementEvent event, List<Supplier> suppliers, boolean overWrite, String principal, Map<String, String> options);
 
     public void deleteSupplier(ProcurementEvent event, String organisationId, String principal);
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/processors/store/AbstractSupplierStore.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/processors/store/AbstractSupplierStore.java
@@ -3,6 +3,7 @@ package uk.gov.crowncommercial.dts.scale.cat.processors.store;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
 import uk.gov.crowncommercial.dts.scale.cat.model.entity.OrganisationMapping;
+import uk.gov.crowncommercial.dts.scale.cat.model.entity.ProcurementEvent;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.EventSuppliers;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.OrganizationReference1;
 import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.CompanyData;
@@ -10,10 +11,7 @@ import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Supplier;
 import uk.gov.crowncommercial.dts.scale.cat.processors.SupplierStore;
 import uk.gov.crowncommercial.dts.scale.cat.repo.RetryableTendersDBDelegate;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public abstract class AbstractSupplierStore implements SupplierStore {
@@ -91,5 +89,9 @@ public abstract class AbstractSupplierStore implements SupplierStore {
         return retryableTendersDBDelegate.findOrganisationMappingByOrganisationId(organisationId)
                 .orElseThrow(() -> new IllegalArgumentException(
                         String.format(ERR_MSG_FMT_SUPPLIER_NOT_FOUND, organisationId)));
+    }
+
+    public List<Supplier> storeSuppliers(ProcurementEvent event, List<Supplier> suppliers, boolean overWrite, String principal, Map<String, String> options) {
+        return storeSuppliers(event, suppliers, overWrite, principal);
     }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/processors/store/DOS6SupplierStore.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/processors/store/DOS6SupplierStore.java
@@ -9,7 +9,10 @@ import uk.gov.crowncommercial.dts.scale.cat.model.jaggaer.Supplier;
 import uk.gov.crowncommercial.dts.scale.cat.processors.SupplierStore;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -20,7 +23,11 @@ public class DOS6SupplierStore implements SupplierStore {
     private final DatabaseSupplierStore databaseSupplierStore;
 
 
-    private SupplierStore getSupplierStore(ProcurementEvent event) {
+    private SupplierStore getSupplierStore(ProcurementEvent event, Map<String, String> options) {
+
+        SupplierStore store = getSupplierStore(options);
+        if(null != store)
+            return store;
 
         Instant publishDate = event.getPublishDate();
         if (null != publishDate && publishDate.isBefore(Instant.now())) {
@@ -31,6 +38,23 @@ public class DOS6SupplierStore implements SupplierStore {
             log.debug("Choosing Jaggaer supplier store to manage the suppliers");
             return jaggaerSupplierStore;
         }
+    }
+
+    private SupplierStore getSupplierStore(Map<String, String> options){
+        if(null != options){
+            String store = options.get("store");
+            if(null != store){
+                switch (store){
+                    case "jaggaer":
+                        return jaggaerSupplierStore;
+                    case "database":
+                        return databaseSupplierStore;
+                    default:
+                        return null;
+                }
+            }
+        }
+        return null;
     }
 
     @Override
@@ -52,17 +76,22 @@ public class DOS6SupplierStore implements SupplierStore {
 
     @Override
     public EventSuppliers storeSuppliers(ProcurementEvent event, EventSuppliers eventSuppliers, String principal) {
-        return getSupplierStore(event).storeSuppliers(event, eventSuppliers, principal);
+        return getSupplierStore(event, null).storeSuppliers(event, eventSuppliers, principal);
     }
 
     @Override
     public List<Supplier> storeSuppliers(ProcurementEvent event, List<Supplier> suppliers, boolean overWrite, String principal) {
-        return getSupplierStore(event).storeSuppliers(event, suppliers,overWrite, principal);
+        return getSupplierStore(event, null).storeSuppliers(event, suppliers,overWrite, principal);
+    }
+
+    @Override
+    public List<Supplier> storeSuppliers(ProcurementEvent event, List<Supplier> suppliers, boolean overWrite, String principal, Map<String, String> options) {
+        return getSupplierStore(event, options).storeSuppliers(event, suppliers,overWrite, principal);
     }
 
     @Override
     public void deleteSupplier(ProcurementEvent event, String organisationId, String principal) {
-        getSupplierStore(event).deleteSupplier(event, organisationId, principal);
+        getSupplierStore(event, null).deleteSupplier(event, organisationId, principal);
     }
 
     @Override

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/asyncprocessors/JaggaerSupplierPush.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/asyncprocessors/JaggaerSupplierPush.java
@@ -20,6 +20,8 @@ import uk.gov.crowncommercial.dts.scale.cat.service.SupplierService;
 
 import javax.transaction.Transactional;
 import java.util.List;
+import java.util.Map;
+import static java.util.Map.entry;
 
 @RequiredArgsConstructor
 @Component("JaggaerSupplierPush")
@@ -51,9 +53,10 @@ public class JaggaerSupplierPush implements AsyncConsumer<JaggaerSupplierEventDa
         }
 
         if(null != suppliers) {
+            Map<String, String> options = Map.ofEntries(entry("store", "jaggaer"));
             SupplierStore store = factory.getStore(event);
             try {
-                store.storeSuppliers(event, suppliers, data.getOverWrite(), principal);
+                store.storeSuppliers(event, suppliers, data.getOverWrite(), principal, options);
             }catch(JaggaerApplicationException jae){
                 if(jae.getMessage().contains("Code: [-998]")){
                     throw new RetryableException("-998", jae.getMessage(), jae);

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventServiceTest.java
@@ -812,6 +812,8 @@ class ProcurementEventServiceTest {
     when(validationService.validateProjectAndEventIds(PROC_PROJECT_ID, PROC_EVENT_ID))
         .thenReturn(event);
     when(jaggaerService.getRfxWithSuppliers(RFX_ID)).thenReturn(rfxResponse);
+    when(organisationMappingRepo.findByExternalOrganisationIdIn(Set.of(JAGGAER_SUPPLIER_ID)))
+            .thenReturn(Set.of(orgMapping));
     when(organisationMappingRepo.findByExternalOrganisationId(JAGGAER_SUPPLIER_ID))
         .thenReturn(Optional.of(orgMapping));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://crowncommercialservice.atlassian.net/browse/SCAT-8220

### Change description ###
for DOS6, if the event is published before the suppliers are pushed, it ends up stored in the database. 
This change overrides the store selection and will always use Jaggaer store, when called from JaggaerSupplierPush.


### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
