### PR TITLE
Add API key authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - "$HOME/.m2"
 branches:
   only:
-    - "/^(feature|bugfix)\\/(SCC|SCAT|CON|CAS)-[0-9]+.*$/"
+    - "/^(feature|bugfix)\\/(SCC|SCAT|CON|CAS|EI)-[0-9]+.*$/"
     - "/^(release)\\/.*$/"
     - "/^snyk-(upgrade|fix)-[a-z0-9]+$/"
     - develop

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/Authorities.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/Authorities.java
@@ -1,0 +1,16 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth;
+
+/**
+ * List known authorities used for role/permission checking.
+ */
+public class Authorities {
+
+  public static String CAT_USER_ROLE = "CAT_USER";
+  public static String CAT_ADMINISTRATOR_ROLE = "CAT_ADMINISTRATOR";
+  public static String ACCESS_CAT_ROLE = "ACCESS_CAT";
+
+  public static String JAEGGER_BUYER_ROLE = "JAEGGER_BUYER";
+  public static String JAEGGER_SUPPLIER_ROLE = "JAEGGER_SUPPLIER";
+    
+  public static final String ESOURCING_ROLE = "ESOURCING";
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyAuthFilter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyAuthFilter.java
@@ -1,0 +1,30 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth.apikey;
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
+/**
+ * Spring security authentication filter for HTTP header based API Key authentication. 
+ */
+public class ApiKeyAuthFilter extends AbstractPreAuthenticatedProcessingFilter {
+
+  private final String headerName;
+
+  public ApiKeyAuthFilter(final String headerName) {
+    if (headerName == null || headerName.isEmpty()) {
+      throw new IllegalArgumentException("headerName");
+    }
+    this.headerName = headerName;
+  }
+
+  @Override
+  protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+    return request.getHeader(headerName);
+  }
+
+  @Override
+  protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+    // There are no credentials when using API key
+    return null;
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyAuthManager.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyAuthManager.java
@@ -1,0 +1,33 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth.apikey;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Spring security AuthenticationManager for HTTP header based API Key authentication.
+ * 
+ * This delegates the actual API Key checking/details retrieval to a provider.
+ */
+@RequiredArgsConstructor
+public class ApiKeyAuthManager implements AuthenticationManager {
+
+  final ApiKeyDetailsProvider apiKeyDetailsProvider;
+
+  @Override
+  public Authentication authenticate(Authentication authentication) {
+
+    String principal = (String) authentication.getPrincipal();
+
+    // check key
+    if (StringUtils.isBlank(principal)) {
+      throw new BadCredentialsException("API Key is missing");
+    }
+
+    return apiKeyDetailsProvider.findDetailsByKey(principal).map((details) -> {
+      return new ApiKeyAuthToken(details.getKey(), details.getAuthorities());
+    }).orElseThrow(() -> new BadCredentialsException("API Key not found"));
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyAuthToken.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyAuthToken.java
@@ -1,0 +1,36 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth.apikey;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.Transient;
+
+/**
+ * Spring security authentication token for HTTP header based API Key authentication.
+ * 
+ * The API Key authentication is not session based, hence makred as Transient.
+ */
+@Transient
+public class ApiKeyAuthToken extends AbstractAuthenticationToken {
+
+  private static final long serialVersionUID = 1L;
+
+  private String apiKey;
+
+  public ApiKeyAuthToken(String apiKey, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    this.apiKey = apiKey;
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Object getCredentials() {
+    return null;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return apiKey;
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyDetails.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyDetails.java
@@ -1,0 +1,19 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth.apikey;
+
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * POJO for holding API Key details. This is limited to just the key and associated granted
+ * authorities at the moment.
+ */
+@Value
+@Builder
+public class ApiKeyDetails {
+
+  String key;
+
+  Collection<GrantedAuthority> authorities;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyDetailsProvider.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ApiKeyDetailsProvider.java
@@ -1,0 +1,12 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth.apikey;
+
+import java.util.Optional;
+
+/**
+ * Interface to abstract the retrieval of details associated with an API Key allowing different
+ * mechanism to be supported, but primarily to ease testing.
+ */
+public interface ApiKeyDetailsProvider {
+
+  Optional<ApiKeyDetails> findDetailsByKey(String key);
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ConfigPropertiesApiKeyDetailsProvider.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/auth/apikey/ConfigPropertiesApiKeyDetailsProvider.java
@@ -1,0 +1,43 @@
+package uk.gov.crowncommercial.dts.scale.cat.auth.apikey;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.core.authority.AuthorityUtils;
+import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApiKeyConfig;
+
+/**
+ * Implementation of the ApiKeyDetailsProvider that retrieves details from the Spring Boot
+ * application config properties.
+ */
+@RequiredArgsConstructor
+public class ConfigPropertiesApiKeyDetailsProvider implements ApiKeyDetailsProvider {
+
+  private final ApiKeyConfig apiKeyConfig;
+
+  @Override
+  public Optional<ApiKeyDetails> findDetailsByKey(String key) {
+
+    // catch no key configured (avoid issues with null/empty/blank keys)
+    if (StringUtils.isBlank(apiKeyConfig.getKey())) {
+      return Optional.empty();
+    }
+
+    // catch no key passed in (avoid issues with null/empty/blank keys)
+    if (StringUtils.isBlank(key)) {
+      return Optional.empty();
+    }
+
+    // check for match
+    if (!Objects.equals(apiKeyConfig.getKey(), key)) {
+      return Optional.empty();
+    }
+
+    // build the details
+    return Optional.of(ApiKeyDetails.builder().key(apiKeyConfig.getKey())
+        .authorities(
+            AuthorityUtils.commaSeparatedStringToAuthorityList(apiKeyConfig.getAuthorities()))
+        .build());
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApiKeyConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/ApiKeyConfig.java
@@ -1,0 +1,21 @@
+package uk.gov.crowncommercial.dts.scale.cat.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.Data;
+
+/**
+ * Spring configuration class for the API Key authentication mechanism.
+ */
+@ConfigurationProperties(prefix = "config.auth.apikey", ignoreUnknownFields = true)
+@Data
+public class ApiKeyConfig {
+
+  /** HTTP header used for passing the API Key */
+  private String header;
+  
+  /** single API Key */
+  private String key;
+  
+  /** comma separated list of authorities for the given API Key */
+  private String authorities;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/TendersController.java
@@ -3,6 +3,7 @@ package uk.gov.crowncommercial.dts.scale.cat.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -13,12 +14,15 @@ import uk.gov.crowncommercial.dts.scale.cat.interceptors.TrackExecutionTime;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.GetUserResponse;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.RegisterUserResponse;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.RegisterUserResponse.UserActionEnum;
+import uk.gov.crowncommercial.dts.scale.cat.model.generated.Release;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.User;
 import uk.gov.crowncommercial.dts.scale.cat.model.generated.ViewEventType;
 import uk.gov.crowncommercial.dts.scale.cat.service.ProfileManagementService;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -96,5 +100,14 @@ public class TendersController extends AbstractRestController {
    log.info("getAllUsers for on behalf of principal: {} ", principal);
    // We are not retrieving org users based on organisationId
    return profileManagementService.getOrgUsers(principal);
+  }
+
+  @GetMapping("/projects/deltas")
+  @TrackExecutionTime
+  public List<Release> getProjectsDelta(
+          @RequestParam(name = "lastSuccessRun", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final Date lastSuccessRun) {
+
+      log.info("getProjectsDelta for on behalf of principal: TBD ");
+      return Collections.emptyList();
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,12 @@ config:
       - zip
     maxSize: 314572800 #300MB
     maxTotalSize: 1073741824 #1GB
-
+  auth:
+    apikey:
+      header: x-api-key
+#      key: "SET IN ENV"  
+      authorities: ESOURCING  
+  
   external:
     jaggaer:
 #      baseUrl: "SET IN ENV"

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EsourcingTendersControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/EsourcingTendersControllerTest.java
@@ -1,0 +1,96 @@
+package uk.gov.crowncommercial.dts.scale.cat.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.crowncommercial.dts.scale.cat.auth.Authorities;
+import uk.gov.crowncommercial.dts.scale.cat.auth.apikey.ApiKeyDetails;
+import uk.gov.crowncommercial.dts.scale.cat.auth.apikey.ApiKeyDetailsProvider;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApiKeyConfig;
+import uk.gov.crowncommercial.dts.scale.cat.config.ApplicationFlagsConfig;
+import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
+import uk.gov.crowncommercial.dts.scale.cat.service.ProfileManagementService;
+import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
+
+/**
+ * Web (mock MVC) for the ESourcing tenders endpoints.
+ */
+@WebMvcTest(TendersController.class)
+@Import({TendersAPIModelUtils.class, JaggaerAPIConfig.class, GlobalErrorHandler.class,
+    ApplicationFlagsConfig.class, ApiKeyConfig.class})
+@ActiveProfiles("test")
+class EsourcingTendersControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private ProfileManagementService profileManagementService;
+
+  @MockBean
+  private ApiKeyDetailsProvider apiKeyDetailsProvider;
+
+  @Test
+  void getProjectDeltas_200_OK() throws Exception {
+
+    String key = "jgkepi7df-890g7s-8g7usidfgpoid7yf";
+    when(apiKeyDetailsProvider.findDetailsByKey(key)).thenReturn(Optional
+        .of(ApiKeyDetails.builder().key(key)
+            .authorities(AuthorityUtils.commaSeparatedStringToAuthorityList(Authorities.ESOURCING_ROLE))
+        .build()));
+
+    mockMvc
+        .perform(get("/tenders/projects/deltas")
+            .queryParam("lastSuccessRun", "2000-10-31T01:30:00.000-05:00")
+            .header("x-api-key", key).accept(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON));
+  }
+  
+  @Test
+  void getProjectDeltas_403_Forbidden() throws Exception {
+
+    // provide a valid key but the key deosn't provide the required authorities for this end point
+    String key = "jgkepi7df-890g7s-8g7usidfgpoid7yf";
+    when(apiKeyDetailsProvider.findDetailsByKey(key)).thenReturn(Optional
+        .of(ApiKeyDetails.builder().key(key)
+            .authorities(AuthorityUtils.commaSeparatedStringToAuthorityList(Authorities.CAT_ADMINISTRATOR_ROLE))
+        .build()));
+
+    mockMvc
+        .perform(get("/tenders/projects/deltas")
+            .queryParam("lastSuccessRun", "2000-10-31T01:30:00.000-05:00")
+            .header("x-api-key", key).accept(APPLICATION_JSON))
+        .andDo(print()).andExpect(status().isForbidden())
+        .andExpect(content().contentType(APPLICATION_JSON));
+  }
+  
+  @Test
+  void getProjectDeltas_401_Unauthorized() throws Exception {
+    
+    // provide an invalid key
+    String key = "jgkepi7df-890g7s-8g7usidfgpoid7yf";
+    when(apiKeyDetailsProvider.findDetailsByKey(key)).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(get("/tenders/projects/deltas")
+            .queryParam("lastSuccessRun", "2000-10-31T01:30:00.000-05:00")
+            .header("x-api-key", key).accept(APPLICATION_JSON)
+            )
+        .andDo(print()).andExpect(status().isUnauthorized())
+        .andExpect(content().contentType(APPLICATION_JSON));
+  }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

EI-92

### Change description ###

Adds an additional Spring Security based authentication mechanism for checking headers against an API key that is present in the application configuration. On successful authentication the authorities defined in the application configuration are set on the security context.

### Does this PR introduce a breaking change?

- [X] No

**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
