### PR TITLE
Add SSM Param for ESourcing API Key to terraform

### DIFF
--- a/iac/modules/cat-service/main.tf
+++ b/iac/modules/cat-service/main.tf
@@ -172,6 +172,11 @@ data "aws_ssm_parameter" "gov_uk_notify_user_reg_target_email" {
   name = "/cat/${var.environment == "prd" ? "prd" : "default"}/gov-uk-notify/user-registration/target-email"
 }
 
+# ESourcing/API Gateway authn/authz
+data "aws_ssm_parameter" "auth_api_key" {
+  name = "/cat/${var.environment}/auth/api-key"
+}
+
 resource "cloudfoundry_app" "cat_service" {
   annotations = {}
   buildpack   = var.buildpack
@@ -234,6 +239,9 @@ resource "cloudfoundry_app" "cat_service" {
     "config.external.notification.user-registration.template-id": data.aws_ssm_parameter.gov_uk_notify_user_reg_template_id.value
     "config.external.notification.user-registration.invalid-duns-template-id": data.aws_ssm_parameter.gov_uk_notify_user_invalid_duns_template_id.value
     "config.external.notification.user-registration.target-email": data.aws_ssm_parameter.gov_uk_notify_user_reg_target_email.value
+    
+    # ESourcing
+    "config.auth.apikey.key": data.aws_ssm_parameter.auth_api_key
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"


### PR DESCRIPTION
### JIRA link (if applicable) ###

EI-92

### Change description ###

Add SSM parameter to the terraform scripts to inject the API Key from the SSM Parameter Store into the environment. SSM Paramater created is "/cat/${var.environment}/auth/api-key"

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines - I think so
- [X] README and other documentation has been updated / added (if needed) - not needed
- [X] tests have been updated / new tests has been added (if needed) - not needed
