### PR TITLE
RenameSuggestion

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/JaggaerService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/JaggaerService.java
@@ -157,7 +157,7 @@ public class JaggaerService {
                     "Unexpected error retrieving rfx"));
   }
 
-  public ExportRfxResponse getRfxWithWithBuyerAndSellerAttachments(final String externalEventId) {
+  public ExportRfxResponse getRfxWithBuyerAndSellerAttachments(final String externalEventId) {
 
     final var exportRfxUri = jaggaerAPIConfig.getExportRfxWithBuyerAndSellerAttachments().get(ENDPOINT);
     return ofNullable(jaggaerWebClient.get().uri(exportRfxUri, externalEventId).retrieve()

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementEventService.java
@@ -1301,7 +1301,7 @@ public class ProcurementEventService implements EventService {
                                                     final String principal) {
         log.debug("Export all Documents from Event {}", eventId);
         var event = validationService.validateProjectAndEventIds(procId, eventId);
-        var exportRfxResponse = jaggaerService.getRfxWithWithBuyerAndSellerAttachments(event.getExternalEventId());
+        var exportRfxResponse = jaggaerService.getRfxWithBuyerAndSellerAttachments(event.getExternalEventId());
         var status = jaggaerAPIConfig.getRfxStatusToTenderStatus()
                 .get(exportRfxResponse.getRfxSetting().getStatusCode());
         var attachments = new ArrayList<DocumentAttachment>();

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/QuestionAndAnswerService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/QuestionAndAnswerService.java
@@ -109,7 +109,7 @@ public class QuestionAndAnswerService {
     }
 
     var covertedQandAList =
-        covertQandAList(questionAndAnswerRepo.findByEventId(procurementEvent.getId()));
+        convertQandAList(questionAndAnswerRepo.findByEventId(procurementEvent.getId()));
     var agreementNo = procurementEvent.getProject().getCaNumber();
     var agreementDetails = agreementsService.getAgreementDetails(agreementNo);
     var lotDetails = agreementsService.getLotDetails(agreementNo, procurementEvent.getProject().getLotNumber());
@@ -129,7 +129,7 @@ public class QuestionAndAnswerService {
     //Validate event
     var procurementEvent = validationService.validateProjectAndEventIds(projectId, eventId);
     var covertedQandAList =
-        covertQandAList(questionAndAnswerRepo.findByEventId(procurementEvent.getId()));
+        convertQandAList(questionAndAnswerRepo.findByEventId(procurementEvent.getId()));
     var agreementNo = procurementEvent.getProject().getCaNumber();
     var agreementDetails = agreementsService.getAgreementDetails(agreementNo);
     var lotDetails =
@@ -153,7 +153,7 @@ public class QuestionAndAnswerService {
             ZoneId.systemDefault()));
   }
 
-  private List<QandA> covertQandAList(Set<QuestionAndAnswer> questionAndAnswerList) {
+  private List<QandA> convertQandAList(Set<QuestionAndAnswer> questionAndAnswerList) {
     return questionAndAnswerList.stream().map(this::convertQandA).collect(Collectors.toList());
   }
 


### PR DESCRIPTION

### Change description ###
We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find two non-descriptive method names in your repository:
```java
/* Non-descriptive Method Name in src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/QuestionAndAnswerService.java */
  private List<QandA> covertQandAList(Set<QuestionAndAnswer> questionAndAnswerList) {
    return questionAndAnswerList.stream().map(this::convertQandA).collect(Collectors.toList());
  }

```
We considered "covertQandAList" as non-descriptive because it contains a typo, i.e., "covert" -> "convert", which could be confusing.  

```java
/* Non-descriptive Method Name in src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/JaggaerService.java */
  public ExportRfxResponse getRfxWithWithBuyerAndSellerAttachments(final String externalEventId) {

    final var exportRfxUri = jaggaerAPIConfig.getExportRfxWithBuyerAndSellerAttachments().get(ENDPOINT);
    return ofNullable(jaggaerWebClient.get().uri(exportRfxUri, externalEventId).retrieve()
            .bodyToMono(ExportRfxResponse.class)
            .block(ofSeconds(jaggaerAPIConfig.getTimeoutDuration())))
            .orElseThrow(() -> new JaggaerApplicationException(INTERNAL_SERVER_ERROR.value(),
                    "Unexpected error retrieving rfx"));
  }
```
We considered "getRfxWithWithBuyerAndSellerAttachments" as non-descriptive because it has a redundant "with". We have corrected it and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
