### PR TITLE
Add single project summary fetch endpoint to Tenders

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/controller/ProjectsController.java
@@ -71,6 +71,17 @@ public class ProjectsController extends AbstractRestController {
     return procurementProjectService.getProjects(principal, searchType, searchTerm, page, pageSize);
   }
 
+  /**
+   * Returns a single ProjectPackageSummary model for a given project ID
+   */
+  @GetMapping("/{projectId}/summary")
+  @TrackExecutionTime
+  public ProjectPackageSummary getProjectSummary(@PathVariable("projectId") final Integer projectId, final JwtAuthenticationToken authentication) {
+    // Grab the principal from the JWT passed to us, then use it and the requested Project ID to fetch the relevant project summary
+    String principal = getPrincipalFromJwt(authentication);
+    return procurementProjectService.getProjectSummary(principal, projectId);
+  }
+
   @PostMapping("/agreements")
   @TrackExecutionTime
   public DraftProcurementProject createProcurementProject(

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ProcurementProjectService.java
@@ -558,6 +558,7 @@ public class ProcurementProjectService {
                 .orElse(null);
 
         if (projectMapping != null) {
+          // Great, now fetch the final details we need and map to our summary model
           Set<String> externalEventIds = projectMapping.getProject().getProcurementEvents().stream().map(ProcurementEvent::getExternalEventId).collect(Collectors.toSet());
 
           if (!externalEventIds.isEmpty()) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/CUI-105


### Change description ###
Adds a GET endpoint for a single project summary.  Saves us needing to use massively unperformant endpoints for simple things


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
