### PR TITLE
Add Gcloud Assessment Summaries route to Tenders

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/assessment/GCloudAssessmentSummary.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/assessment/GCloudAssessmentSummary.java
@@ -1,0 +1,22 @@
+package uk.gov.crowncommercial.dts.scale.cat.model.assessment;
+
+import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.AssessmentStatus;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Model containing summary information about a specific GCloud assessment
+ */
+public class GCloudAssessmentSummary {
+    public Integer id;
+
+    public String name;
+
+    public String criteria;
+
+    public String description;
+
+    public OffsetDateTime lastUpdate;
+
+    public AssessmentStatus status;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/assessment/GCloudAssessmentSummary.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/model/assessment/GCloudAssessmentSummary.java
@@ -1,5 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.cat.model.assessment;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.AssessmentStatus;
 
 import java.time.OffsetDateTime;
@@ -8,13 +9,14 @@ import java.time.OffsetDateTime;
  * Model containing summary information about a specific GCloud assessment
  */
 public class GCloudAssessmentSummary {
+    @JsonProperty("assessment-id")
     public Integer id;
 
-    public String name;
+    public String assessmentName;
 
-    public String criteria;
+    public String dimensionRequirements;
 
-    public String description;
+    public String resultsSummary;
 
     public OffsetDateTime lastUpdate;
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/GCloudAssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/GCloudAssessmentService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.crowncommercial.dts.scale.cat.exception.AuthorisationFailureException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.NotSupportedException;
 import uk.gov.crowncommercial.dts.scale.cat.exception.ResourceNotFoundException;
+import uk.gov.crowncommercial.dts.scale.cat.model.assessment.GCloudAssessmentSummary;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.AssessmentStatus;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.GCloudAssessment;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.GCloudResult;
@@ -168,6 +169,38 @@ public class GCloudAssessmentService {
                 retryableTendersDBDelegate.saveAll(gCloudAssessmentResultSet);
             }
         }
+    }
+
+    /**
+     * Gets a summary model for a GCloud Assessment
+     */
+    @Transactional
+    public GCloudAssessmentSummary getGcloudAssessmentSummary(final Integer assessmentId) {
+        // Grab the assessment details from the DB
+        GCloudAssessmentEntity assessmentModel = retryableTendersDBDelegate.findGcloudAssessmentById(assessmentId).orElse(null);
+
+        if (assessmentModel != null) {
+            // We appear to have data, so map it to our desired output model
+            GCloudAssessmentSummary model = new GCloudAssessmentSummary();
+
+            model.id = assessmentModel.getId();
+            model.description = assessmentModel.getResultsSummary();
+            model.criteria = assessmentModel.getDimensionRequirements();
+            model.name = assessmentModel.getAssessmentName();
+            model.status = AssessmentStatus.fromValue(assessmentModel.getStatus().toString().toLowerCase());
+
+            Timestamps timestamps = assessmentModel.getTimestamps();
+            if (timestamps.getUpdatedAt() != null) {
+                model.lastUpdate = OffsetDateTime.ofInstant(timestamps.getUpdatedAt(), ZoneId.of(TIMEZONE_NAME));
+            } else {
+                model.lastUpdate = OffsetDateTime.ofInstant(timestamps.getCreatedAt(), ZoneId.of(TIMEZONE_NAME));
+            }
+
+            return model;
+        }
+
+        // If we've got this far, there's been an issue or no data was found - return null
+        return null;
     }
 
     /**

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/GCloudAssessmentService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/ca/GCloudAssessmentService.java
@@ -184,9 +184,9 @@ public class GCloudAssessmentService {
             GCloudAssessmentSummary model = new GCloudAssessmentSummary();
 
             model.id = assessmentModel.getId();
-            model.description = assessmentModel.getResultsSummary();
-            model.criteria = assessmentModel.getDimensionRequirements();
-            model.name = assessmentModel.getAssessmentName();
+            model.resultsSummary = assessmentModel.getResultsSummary();
+            model.dimensionRequirements = assessmentModel.getDimensionRequirements();
+            model.assessmentName = assessmentModel.getAssessmentName();
             model.status = AssessmentStatus.fromValue(assessmentModel.getStatus().toString().toLowerCase());
 
             Timestamps timestamps = assessmentModel.getTimestamps();

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/GCloudAssessmentsControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/controller/GCloudAssessmentsControllerTest.java
@@ -17,6 +17,7 @@ import uk.gov.crowncommercial.dts.scale.cat.config.JaggaerAPIConfig;
 import uk.gov.crowncommercial.dts.scale.cat.config.OAuth2Config;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.GCloudAssessment;
 import uk.gov.crowncommercial.dts.scale.cat.model.capability.generated.GCloudResult;
+import uk.gov.crowncommercial.dts.scale.cat.service.ca.AssessmentService;
 import uk.gov.crowncommercial.dts.scale.cat.service.ca.GCloudAssessmentService;
 import uk.gov.crowncommercial.dts.scale.cat.utils.TendersAPIModelUtils;
 
@@ -44,6 +45,9 @@ public class GCloudAssessmentsControllerTest {
 
     @MockBean
     private GCloudAssessmentService assessmentService;
+
+    @MockBean
+    private AssessmentService coreAssessmentService;
 
     @Autowired
     private ObjectMapper objectMapper;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://crowncommercialservice.atlassian.net/browse/CUI-106


### Change description ###
Adds a GET endpoint for a list of summaries of a user's GCloud Assessments. Saves us needing to spam assessment detail endpoints endlessly for basic summary info.


### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
