### PR TITLE
GMBP-252: Add support for native AWS environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG APP_DIR=/app
+FROM maven:3.9.5-eclipse-temurin-17 as build
+COPY . /build
+RUN cd /build && mvn package
+
+FROM eclipse-temurin:17.0.8.1_1-jre
+ARG APP_DIR
+RUN /usr/sbin/groupadd -r appuser && \
+    /usr/sbin/useradd --no-log-init -r -g appuser appuser && \
+    # Create application directory
+    install -o appuser -g appuser -d ${APP_DIR}
+COPY --chown=appuser:appuser --from=build /build/target/ccs-scale-cat-service-*.jar ${APP_DIR}/cat.jar
+USER appuser
+WORKDIR ${APP_DIR}
+EXPOSE 8080
+ENTRYPOINT [ "java", "-jar", "./cat.jar" ]

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadAPIConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadAPIConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import lombok.Data;
+import java.util.Optional;
 
 /**
  *
@@ -21,8 +22,8 @@ public class DocumentUploadAPIConfig {
 
   // AWS-S3
   private String awsRegion;
-  private String awsAccessKeyId;
-  private String awsSecretKey;
+  private Optional<String> awsAccessKeyId;
+  private Optional<String> awsSecretKey;
   private String s3Bucket;
 
   private Integer timeoutDuration;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadS3ClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/DocumentUploadS3ClientConfig.java
@@ -19,11 +19,16 @@ public class DocumentUploadS3ClientConfig {
 
   @Bean("documentUploadS3Client")
   public AmazonS3 amazonS3() {
-    var awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(
-        documentUploadAPIConfig.getAwsAccessKeyId(), documentUploadAPIConfig.getAwsSecretKey()));
+    if(documentUploadAPIConfig.getAwsAccessKeyId() != null) {
+      var awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+          documentUploadAPIConfig.getAwsAccessKeyId().toString(), documentUploadAPIConfig.getAwsSecretKey().toString()));
 
-    return AmazonS3ClientBuilder.standard().withRegion(documentUploadAPIConfig.getAwsRegion())
-        .withCredentials(awsCredentials).build();
+      return AmazonS3ClientBuilder.standard().withRegion(documentUploadAPIConfig.getAwsRegion())
+          .withCredentials(awsCredentials).build();
+    } else {
+      return AmazonS3ClientBuilder.standard().withRegion(documentUploadAPIConfig.getAwsRegion())
+          .build();
+    }
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/OAuth2Config.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/OAuth2Config.java
@@ -41,7 +41,11 @@ public class OAuth2Config {
 
     log.info("Configuring resource server...");
 
-    http.authorizeHttpRequests(authz ->
+    http
+      .authorizeHttpRequests()
+      .requestMatchers("/actuator/**").permitAll()
+      .and()
+      .authorizeHttpRequests(authz ->
       authz
         .requestMatchers(HttpMethod.GET,"/tenders/projects/*").permitAll()
         .requestMatchers(HttpMethod.GET,"/tenders/projects/*/events/*/documents/export").permitAll()

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/TendersS3ClientConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/TendersS3ClientConfig.java
@@ -30,11 +30,16 @@ public class TendersS3ClientConfig {
   @Bean("tendersS3Client")
   public AmazonS3 amazonS3(final AWSS3Service awsS3Bucket) {
     var bucketCredentials = awsS3Bucket.getCredentials();
-    var awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(
-        bucketCredentials.getAwsAccessKeyId(), bucketCredentials.getAwsSecretAccessKey()));
+    if(bucketCredentials.getAwsAccessKeyId() != null) {
+      var awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+          bucketCredentials.getAwsAccessKeyId().toString(), bucketCredentials.getAwsSecretAccessKey().toString()));
 
-    return AmazonS3ClientBuilder.standard().withRegion(bucketCredentials.getAwsRegion())
-        .withCredentials(awsCredentials).build();
+      return AmazonS3ClientBuilder.standard().withRegion(bucketCredentials.getAwsRegion())
+          .withCredentials(awsCredentials).build();
+    } else {
+      return AmazonS3ClientBuilder.standard().withRegion(bucketCredentials.getAwsRegion())
+          .build();
+    }
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/AWSS3Credentials.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/AWSS3Credentials.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
+import java.util.Optional;
 
 @Value
 @Builder
@@ -17,9 +18,9 @@ public class AWSS3Credentials {
   String bucketName;
 
   @JsonProperty("aws_access_key_id")
-  String awsAccessKeyId;
+  Optional<String> awsAccessKeyId;
 
   @JsonProperty("aws_secret_access_key")
-  String awsSecretAccessKey;
+  Optional<String> awsSecretAccessKey;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/OpensearchCredentials.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/config/paas/OpensearchCredentials.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
+import java.util.Optional;
 
 @Value
 @Builder
@@ -14,10 +15,10 @@ public class OpensearchCredentials {
     String hostname;
 
     @JsonProperty("username")
-    String username;
+    Optional<String> username;
 
     @JsonProperty("password")
-    String password;
+    Optional<String> password;
 
     @JsonProperty("port")
     String port;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://crowncommercialservice.atlassian.net/browse/GMBP-252 (Dockerfile build)
https://crowncommercialservice.atlassian.net/browse/GMBP-273 (Supporting changes in CAT API codebase)

### Change description ###

This PR adds the ability to build a Docker image for CAT API for use in a native AWS environment following the migration from GPaaS.

In support of this, a small number of code changes have been made to better interoperate with this environment:
- Make username and password authentication for OpenSearch optional as the OpenSearch instance in AWS will be local to the VPC in which the CAT API is deployed
- Make AWS access key & secret access key authentication for the Tenders S3 client and Document Upload S3 client optional as they should be using native IAM task role based authentication by default
- Enable Spring Boot Actuator to provide a basic `/actuator/health` endpoint which returns an HTTP 200 for use with load balancer healthchecks

Note that the enabling of Actuator will make an `/actuator/health` endpoint available to any trusted/allowed IP addresses without authentication; Actuator also exposes (by default) endpoints under `/cloudfoundryapplication`. This behaviour can be disabled by setting `management.cloudfoundry.enabled` to `false` if desired.

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
