### PR TITLE
Use GitHub actions to run tests for CI 

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  workflow_call:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/build-push-action@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,22 @@
+name: "Java CI"
+
+on:
+  workflow_call:
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: "Run our tests"
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  run-unit-tests:
+    uses: ./.github/workflows/maven.yml
+
+  run-docker-build:
+    uses: ./.github/workflows/docker-image.yml


### PR DESCRIPTION
### Change description ###

As we are going to move away from using Travis for the CI, make use of GitHub actions so that we can continue to test our code

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
