### PR TITLE
[GMTRP-209] Populate detail field for 401, 403, 404 and 500 erro codes

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/utils/TendersAPIModelUtils.java
@@ -78,9 +78,8 @@ public class TendersAPIModelUtils {
   }
 
   public Errors buildDefaultErrors(final String status, final String title, final String details) {
-    var apiError = new ApiError(status, title,
-        appFlagsConfig.getDevMode() != null && appFlagsConfig.getDevMode() ? details : "");
-    return buildErrors(Arrays.asList(apiError));
+    var apiError = new ApiError(status, title, details);
+    return buildErrors(List.of(apiError));
   }
 
   public Errors buildErrors(final List<ApiError> apiErrors) {

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TendersAPIModelUtilsTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/cat/util/TendersAPIModelUtilsTest.java
@@ -27,9 +27,7 @@ class TendersAPIModelUtilsTest {
   TendersAPIModelUtils utils;
 
   @Test
-  void testBuildDefaultErrors_devMode_true() throws Exception {
-
-    when(appFlagsConfig.getDevMode()).thenReturn(true);
+  void testBuildDefaultErrors() throws Exception {
 
     Errors errors = utils.buildDefaultErrors(ERROR_STATUS, ERROR_TITLE, ERROR_MESSAGE);
 
@@ -39,29 +37,4 @@ class TendersAPIModelUtilsTest {
     assertEquals(ERROR_MESSAGE, errors.getErrors().get(0).getDetail());
   }
 
-  @Test
-  void testBuildDefaultErrors_devMode_false() throws Exception {
-
-    when(appFlagsConfig.getDevMode()).thenReturn(false);
-
-    Errors errors = utils.buildDefaultErrors(ERROR_STATUS, ERROR_TITLE, ERROR_MESSAGE);
-
-    assertEquals(1, errors.getErrors().size());
-    assertEquals(ERROR_STATUS, errors.getErrors().get(0).getStatus());
-    assertEquals(ERROR_TITLE, errors.getErrors().get(0).getTitle());
-    assertEquals("", errors.getErrors().get(0).getDetail());
-  }
-
-  @Test
-  void testBuildDefaultErrors_devMode_null() throws Exception {
-
-    when(appFlagsConfig.getDevMode()).thenReturn(null);
-
-    Errors errors = utils.buildDefaultErrors(ERROR_STATUS, ERROR_TITLE, ERROR_MESSAGE);
-
-    assertEquals(1, errors.getErrors().size());
-    assertEquals(ERROR_STATUS, errors.getErrors().get(0).getStatus());
-    assertEquals(ERROR_TITLE, errors.getErrors().get(0).getTitle());
-    assertEquals("", errors.getErrors().get(0).getDetail());
-  }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://crowncommercialservice.atlassian.net/browse/GMTRP-209

### Change description ###

Populate detail field for status codes 400, 401, 403 and 500 

### Does this PR introduce a breaking change?
No

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
