### PR TITLE
Make logback-classic available for more than just test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,6 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
### Change description ###
Fixes the override of the managed logback-classic dependency so that it's available for the app in general use, so that AWS logging can resume.