### PR TITLE
NCAS-UPT--Sanitize-values-for-dependency-check

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/CriteriaService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/cat/service/CriteriaService.java
@@ -380,7 +380,7 @@ public class CriteriaService {
         .id(r.getOcds().getId())
         .title(r.getOcds().getTitle())
         .description(description)
-        .dataType(DataType.fromValue(r.getOcds().getDataType()))
+        .dataType(DataType.fromValue(r.getOcds().getDataType().toLowerCase()))
         .pattern(r.getOcds().getPattern())
         .expectedValue(new Value1().amount(r.getOcds().getExpectedValue()))
         .minValue(new Value1().amount(r.getOcds().getMinValue()))


### PR DESCRIPTION
**NCAS-UPT:**
 - Lower case passed in data type value, to ensure it matches the format in the model. So either 'String' or 'string' is valid for example.